### PR TITLE
Harden ignition HDD shutdown

### DIFF
--- a/pi/.bashrc
+++ b/pi/.bashrc
@@ -314,16 +314,6 @@ print_vfat_uuid() {
     | sed -r 's/(..)(..)(..)(..)/\4\3-\2\1/'
 }
 
-mntdsk() { # mntdsk sd_card 0383-ABDF
-  fname=$1
-  pth="/mnt/$fname"
-  uuid=$($HOME/scripts/fetch_disk_uuid.sh $fname)
-  fstype=`blkid | grep $uuid | grep -Po '(?<=TYPE=")[^"]*'`
-  if [[ "$fstype" == "hfsplus" ]]; then opts="-o force,rw"; else opts=""; fi
-  sudo mkdir -p $pth && sudo chown pi $pth  && sudo chmod 777 $pth 
-  sudo mount -U $uuid -t $fstype $opts $pth && echo "mounted $fname at $pth"
-}
-
 rm_sm_dirs() { # remove small dirs by size `rm_sm_dirs 1.1G .`
   local threshold="$1"
   local target_dir="${2:-.}"

--- a/pi/configs/.disk_uuids
+++ b/pi/configs/.disk_uuids
@@ -1,8 +1,0 @@
-
-msd_nand2 45a27acc-38c2-4794-95ce-61d8bf32d0fd
-msd_nand2_boot 0383-ABDF
-msd_nand2_settings d815cc0b-cb38-4c7d-a029-631fb74fe785
-msd_nand1 2370748c-1a9f-4dfb-b5d7-97a04e69030a
-msd_nand1_boot 0155-9582
-msd_nand1_settings 84ea185e-c6b2-429e-8188-2da297957ad6
-usbext 6055b78c-27fe-4eb3-9772-10cb14d09e4e

--- a/pi/scripts/backup/abort_backup.sh
+++ b/pi/scripts/backup/abort_backup.sh
@@ -4,11 +4,14 @@
 . /home/pi/scripts/backup/backup_conf.sh
 
 [ -f "$JOB_LOCK" ] || exit 0
-flock -n "$JOB_LOCK" true 2>/dev/null && exit 0  # lock free -> nothing running
+/usr/bin/flock -n "$JOB_LOCK" true 2>/dev/null && exit 0  # lock free -> nothing running
 
 pid=$(tr -cd 0-9 < "$JOB_LOCK")
 if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
   echo "asking backup/restore (pid $pid) to stop before unmount"
   kill -TERM "$pid"
 fi
-flock -w 60 "$JOB_LOCK" true || echo "WARNING: backup/restore did not release its lock within 60s"
+if ! /usr/bin/flock -w 60 "$JOB_LOCK" true; then
+  echo "ERROR: backup/restore did not release its lock within 60s" >&2
+  exit 1
+fi

--- a/pi/scripts/disk_policy.sh
+++ b/pi/scripts/disk_policy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Filesystem labels for rotational USB disks that must be unmounted and
+# explicitly spun down while the van is running.  A newly attached disk is
+# intentionally ignored until its label is added here.
+HDD_LABELS=(
+  movingparts
+  bigboi
+  mbp2tbkup
+)

--- a/pi/scripts/fetch_disk_uuid.sh
+++ b/pi/scripts/fetch_disk_uuid.sh
@@ -1,3 +1,0 @@
-#! /bin/bash
-
-cat /home/pi/.disk_uuids | grep "^$1 " | cut -d' ' -f2

--- a/pi/scripts/hdd_alert.sh
+++ b/pi/scripts/hdd_alert.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Rate-limited ignition HDD shutdown alerts.
+#
+# The active marker is intentionally kept under /run so notification state is
+# cleared by a reboot.  A delivered failure is repeated after 30 minutes only
+# if the exact failure summary is still occurring.  The next successful HDD
+# shutdown sends one recovery notification and clears the marker.
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+HA_STATE_DIR=${HDD_ALERT_STATE_DIR:-/run/lock/vanpi-hdd-alerts}
+HA_ACTIVE_FILE="$HA_STATE_DIR/active"
+HA_COOLDOWN_SECONDS=${HDD_ALERT_COOLDOWN_SECONDS:-1800}
+
+ha_usage() {
+  echo "usage: ${0##*/} failure <summary>" >&2
+  echo "       ${0##*/} recovery" >&2
+}
+
+ha_load_url() {
+  if [[ -z "${NTFY_MESSAGE_URL:-}" && -f /home/pi/secrets/.bash_variables ]]; then
+    # shellcheck disable=SC1091
+    . /home/pi/secrets/.bash_variables
+  fi
+  if [[ -z "${NTFY_MESSAGE_URL:-}" ]]; then
+    echo "ERROR: NTFY_MESSAGE_URL is not configured; cannot send HDD alert" >&2
+    return 1
+  fi
+}
+
+ha_prepare_state_dir() {
+  if [[ -L "$HA_STATE_DIR" || ( -e "$HA_STATE_DIR" && ! -d "$HA_STATE_DIR" ) ]]; then
+    echo "ERROR: $HA_STATE_DIR is not a safe state directory" >&2
+    return 1
+  fi
+  /usr/bin/install -d -m 700 -- "$HA_STATE_DIR"
+}
+
+ha_send() {
+  local title=$1 message=$2 priority=$3 tags=$4
+  ha_load_url || return 1
+  NTFY_URL="$NTFY_MESSAGE_URL" "$script_dir/ntfy_send.sh" \
+    "$title" "$message" "$priority" "$tags"
+}
+
+ha_write_active() {
+  local fingerprint=$1 timestamp=$2 tmp
+  ha_prepare_state_dir || return 1
+  tmp="$HA_STATE_DIR/.active.$$"
+  if ! (umask 077; printf '%s %s\n' "$fingerprint" "$timestamp" > "$tmp"); then
+    echo "ERROR: cannot write HDD alert state" >&2
+    return 1
+  fi
+  if ! /usr/bin/mv -f -- "$tmp" "$HA_ACTIVE_FILE"; then
+    /usr/bin/rm -f -- "$tmp"
+    echo "ERROR: cannot install HDD alert state" >&2
+    return 1
+  fi
+}
+
+ha_failure() {
+  local message=$1 fingerprint_line fingerprint now previous_fingerprint previous_time age
+
+  fingerprint_line=$(printf '%s' "$message" | /usr/bin/sha256sum) || return 1
+  fingerprint=${fingerprint_line%% *}
+  now=$(/usr/bin/date +%s) || return 1
+
+  if [[ -f "$HA_ACTIVE_FILE" ]] &&
+      IFS=' ' read -r previous_fingerprint previous_time < "$HA_ACTIVE_FILE" &&
+      [[ "$previous_fingerprint" == "$fingerprint" && "$previous_time" =~ ^[0-9]+$ ]]; then
+    age=$((now - previous_time))
+    if (( age >= 0 && age < HA_COOLDOWN_SECONDS )); then
+      echo "HDD shutdown alert unchanged; suppressing repeat for $((HA_COOLDOWN_SECONDS - age)) more seconds"
+      return 0
+    fi
+  fi
+
+  ha_send "vanpi HDD shutdown failed" "$message" high warning || return 1
+  ha_write_active "$fingerprint" "$now"
+}
+
+ha_recovery() {
+  [[ -f "$HA_ACTIVE_FILE" ]] || return 0
+  ha_send \
+    "vanpi HDD shutdown recovered" \
+    "The allowlisted HDDs were unmounted and spun down successfully after a previous failure." \
+    default white_check_mark || return 1
+  /usr/bin/rm -f -- "$HA_ACTIVE_FILE"
+}
+
+if [[ ! "$HA_COOLDOWN_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: HDD_ALERT_COOLDOWN_SECONDS must be a positive integer" >&2
+  exit 2
+fi
+
+case "${1:-}" in
+  failure)
+    [[ $# == 2 && -n "$2" ]] || { ha_usage; exit 2; }
+    ha_failure "$2"
+    ;;
+  recovery)
+    [[ $# == 1 ]] || { ha_usage; exit 2; }
+    ha_recovery
+    ;;
+  *)
+    ha_usage
+    exit 2
+    ;;
+esac

--- a/pi/scripts/internet_switches.sh
+++ b/pi/scripts/internet_switches.sh
@@ -1,12 +1,159 @@
 #! /bin/bash
 
-# The ignition hook can invoke this at the same time as the minutely cron job.
-# Serialize the entire policy decision so mounting and unmounting cannot race.
-exec 9>/home/pi/.internet_switches.lock || exit 1
-if ! /usr/bin/flock -w 55 9; then
-  echo "another internet_switches.sh instance held the lock for 55 seconds"
-  exit 1
-fi
+ISW_LOCK_FILE=${ISW_LOCK_FILE:-/home/pi/.internet_switches.lock}
+ISW_LOCK_WAIT_SECONDS=${ISW_LOCK_WAIT_SECONDS:-55}
+ISW_CANARY_DIR=${ISW_CANARY_DIR:-/run/lock/vanpi-internet-switches-canary}
+ISW_OWNER_FILE="$ISW_CANARY_DIR/owner"
+ISW_ALERT_FILE="$ISW_CANARY_DIR/alerted"
+ISW_ALERT_LOCK="$ISW_CANARY_DIR/alert.lock"
+ISW_LOG_FILE=${ISW_LOG_FILE:-/var/log/cron/internet_switches.log}
+ISW_NTFY_SEND=${ISW_NTFY_SEND:-/home/pi/scripts/ntfy_send.sh}
+
+isw_prepare_canary_dir() {
+  if [[ -L "$ISW_CANARY_DIR" || ( -e "$ISW_CANARY_DIR" && ! -d "$ISW_CANARY_DIR" ) ]]; then
+    echo "ERROR: $ISW_CANARY_DIR is not a safe canary state directory" >&2
+    return 1
+  fi
+  /usr/bin/install -d -m 700 -- "$ISW_CANARY_DIR"
+}
+
+isw_record_owner() {
+  local started tmp
+  isw_prepare_canary_dir || return 1
+  started=$(/usr/bin/date +%s) || return 1
+  tmp="$ISW_CANARY_DIR/.owner.$$"
+  if ! (umask 077; printf '%s %s\n' "$$" "$started" > "$tmp"); then
+    echo "ERROR: cannot write internet_switches owner state" >&2
+    return 1
+  fi
+  if ! /usr/bin/mv -f -- "$tmp" "$ISW_OWNER_FILE"; then
+    /usr/bin/rm -f -- "$tmp"
+    echo "ERROR: cannot install internet_switches owner state" >&2
+    return 1
+  fi
+}
+
+isw_cleanup_owner() {
+  local recorded_pid recorded_started
+  [[ -f "$ISW_OWNER_FILE" ]] || return 0
+  IFS=' ' read -r recorded_pid recorded_started < "$ISW_OWNER_FILE" || return 0
+  if [[ "$recorded_pid" == "$$" ]]; then
+    /usr/bin/rm -f -- "$ISW_OWNER_FILE" || true
+  fi
+}
+
+isw_process_snapshot() {
+  local owner_pid=$1 snapshot
+
+  if [[ "$owner_pid" =~ ^[0-9]+$ ]] && kill -0 "$owner_pid" 2>/dev/null; then
+    snapshot=$(/usr/bin/ps -eo pid=,ppid=,stat=,etimes=,wchan:24=,comm= 2>&1 |
+      /usr/bin/awk -v root="$owner_pid" '
+        $1 == root || selected[$2] { selected[$1] = 1; print }
+      ')
+  fi
+
+  if [[ -z "$snapshot" ]]; then
+    snapshot=$(/usr/bin/ps -eo pid=,ppid=,stat=,etimes=,wchan:24=,comm= 2>&1 |
+      /usr/bin/awk '
+        $6 ~ /^(internet_switc|bash|ssh|curl|ls|mount|umount|blkid|findmnt|fsck\.hfsplus|hd-idle|sudo|service|systemctl)$/ { print }
+      ')
+  fi
+
+  printf '%s\n' "${snapshot:-no relevant process snapshot available}"
+}
+
+isw_lock_diagnostics() {
+  local owner_pid=unknown owner_started=unknown now elapsed=unknown
+  local elapsed_display lock_snapshot process_snapshot log_tail diagnostics
+
+  if [[ -f "$ISW_OWNER_FILE" ]]; then
+    IFS=' ' read -r owner_pid owner_started < "$ISW_OWNER_FILE" || {
+      owner_pid=unknown
+      owner_started=unknown
+    }
+  fi
+  now=$(/usr/bin/date +%s 2>/dev/null || true)
+  if [[ "$now" =~ ^[0-9]+$ && "$owner_started" =~ ^[0-9]+$ ]]; then
+    elapsed=$((now - owner_started))
+  fi
+  if [[ "$elapsed" =~ ^[0-9]+$ ]]; then
+    elapsed_display="${elapsed}s"
+  else
+    elapsed_display=unknown
+  fi
+
+  lock_snapshot=$(/usr/bin/timeout 3 /usr/bin/lslocks -n \
+    -o PID,COMMAND,TYPE,MODE,PATH 2>&1 | /usr/bin/grep -F "$ISW_LOCK_FILE" || true)
+  process_snapshot=$(isw_process_snapshot "$owner_pid")
+  log_tail=$(/usr/bin/timeout 3 /usr/bin/tail -n 16 -- "$ISW_LOG_FILE" 2>&1 || true)
+
+  diagnostics=$(printf '%s\n' \
+    "internet_switches could not acquire its lifecycle lock after ${ISW_LOCK_WAIT_SECONDS}s." \
+    "Recorded holder PID: $owner_pid; lock age: $elapsed_display" \
+    "" \
+    "Lock snapshot (PID COMMAND TYPE MODE PATH):" \
+    "${lock_snapshot:-no lock snapshot available}" \
+    "" \
+    "Holder process tree (PID PPID STAT ELAPSED WCHAN COMMAND; arguments omitted):" \
+    "$process_snapshot" \
+    "" \
+    "Recent internet_switches log:" \
+    "${log_tail:-no recent log output available}" |
+    /usr/bin/head -c 3500)
+  printf '%s' "$diagnostics"
+}
+
+isw_write_alert_marker() {
+  local tmp
+  isw_prepare_canary_dir || return 1
+  tmp="$ISW_CANARY_DIR/.alerted.$$"
+  if ! (umask 077; /usr/bin/date -Is > "$tmp"); then
+    echo "ERROR: cannot write internet_switches alert state" >&2
+    return 1
+  fi
+  if ! /usr/bin/mv -f -- "$tmp" "$ISW_ALERT_FILE"; then
+    /usr/bin/rm -f -- "$tmp"
+    echo "ERROR: cannot install internet_switches alert state" >&2
+    return 1
+  fi
+}
+
+isw_notify_lock_timeout() {
+  local diagnostics rc=0
+  isw_prepare_canary_dir || return 1
+
+  exec 8>"$ISW_ALERT_LOCK" || return 1
+  if ! /usr/bin/flock -n 8; then
+    echo "another lock-timeout waiter is handling the internet_switches alert"
+    exec 8>&-
+    return 0
+  fi
+
+  if [[ -f "$ISW_ALERT_FILE" ]]; then
+    echo "internet_switches lock-timeout alert already sent; suppressing repeat"
+  else
+    diagnostics=$(isw_lock_diagnostics)
+    if ! "$ISW_NTFY_SEND" \
+        "vanpi internet_switches stalled" "$diagnostics" high warning; then
+      rc=1
+    elif ! isw_write_alert_marker; then
+      rc=1
+    fi
+  fi
+
+  /usr/bin/flock -u 8 || true
+  exec 8>&-
+  return "$rc"
+}
+
+isw_notify_recovery() {
+  [[ -f "$ISW_ALERT_FILE" ]] || return 0
+  "$ISW_NTFY_SEND" \
+    "vanpi internet_switches recovered" \
+    "A later internet_switches policy run acquired the lifecycle lock and completed successfully." \
+    default white_check_mark || return 1
+  /usr/bin/rm -f -- "$ISW_ALERT_FILE"
+}
 
 conf() { cat /home/pi/mconf/$1* &> /dev/null; }
 
@@ -153,5 +300,39 @@ set_isw_options() {
   else no_internet_ops
   fi
 }
-# 
-set_isw_options
+#
+internet_switches_main() {
+  local rc
+
+  # The ignition hook can invoke this at the same time as the minutely cron
+  # job. Serialize the entire policy decision so mounting and unmounting cannot
+  # race. A waiter that times out acts as the watchdog for a stuck lock holder.
+  exec 9>"$ISW_LOCK_FILE" || return 1
+  if ! /usr/bin/flock -w "$ISW_LOCK_WAIT_SECONDS" 9; then
+    echo "another internet_switches.sh instance held the lock for $ISW_LOCK_WAIT_SECONDS seconds"
+    isw_notify_lock_timeout || true
+    exec 9>&-
+    return 1
+  fi
+
+  isw_record_owner || true
+  trap isw_cleanup_owner EXIT
+
+  set_isw_options
+  rc=$?
+  if (( rc == 0 )); then
+    isw_notify_recovery || true
+  fi
+
+  isw_cleanup_owner
+  trap - EXIT
+  /usr/bin/flock -u 9 || true
+  exec 9>&-
+  return "$rc"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  internet_switches_main "$@"
+  internet_switches_rc=$?
+  exit "$internet_switches_rc"
+fi

--- a/pi/scripts/internet_switches.sh
+++ b/pi/scripts/internet_switches.sh
@@ -1,5 +1,13 @@
 #! /bin/bash
 
+# The ignition hook can invoke this at the same time as the minutely cron job.
+# Serialize the entire policy decision so mounting and unmounting cannot race.
+exec 9>/home/pi/.internet_switches.lock || exit 1
+if ! /usr/bin/flock -w 55 9; then
+  echo "another internet_switches.sh instance held the lock for 55 seconds"
+  exit 1
+fi
+
 conf() { cat /home/pi/mconf/$1* &> /dev/null; }
 
 ubnt_internet_ops() { # nanostation connected; van is likely stationary/parked
@@ -75,7 +83,11 @@ kill_torrent_client() {
 
 start_torrent_client() {
   if [[ "$(grep movingparts /proc/mounts)" ]]; then 
-    [[ "$(pgrep qbittor)" ]] || nohup qbittorrent-nox &
+    if ! pgrep qbittor >/dev/null; then
+      # Background only qbittorrent—not the surrounding conditional—and do
+      # not let the long-lived client inherit fd 9 and hold our flock.
+      nohup qbittorrent-nox 9>&- &
+    fi
   else
     echo "preventing torrent-without-mpdisk"
     kill_torrent_client
@@ -91,6 +103,7 @@ mount_drives() {
     sleep 1
     unmount_drives
   else
+    /home/pi/scripts/umount_disks.sh --clear-spindown-state || return 1
     . /home/pi/scripts/mount_disks.sh
     sleep 3
     echo "drives mounted. starting smb share."
@@ -104,18 +117,8 @@ van_is_running() {
   fi
 }
 
-spindown_drive() {
-  uuid=$1
-  echo "spinning down $uuid"
-  sudo hd-idle -t "/dev/disk/by-uuid/$uuid" # spin-down drive
-}
-
-
 unmount_drives() {
-  /home/pi/scripts/umount_disks.sh
-  sleep 5
-  hdd_uuids=$(cat /home/pi/.disk_uuids | grep -Ev 'msd|usb' | cut -d' ' -f2)
-  for loc in $hdd_uuids; do spindown_drive $loc; done
+  /home/pi/scripts/umount_disks.sh --spindown
 }
 
 stop_service() {

--- a/pi/scripts/mount_disks.sh
+++ b/pi/scripts/mount_disks.sh
@@ -1,92 +1,245 @@
 #! /bin/bash
-# mntdsk sd_card 0383-ABDF
 
+# Set by md_resolve_label on success.
+MD_DEVICE=""
+MD_LABEL_KEY=""
 
-fetch_uuid() { /home/pi/scripts/fetch_disk_uuid.sh $1; }
-fsprop() { 
-  prop=$1 #  LABEL UUID TYPE PARTUUID PARTLABEL
-  sterm=$2
-  match="$(blkln "$sterm" | grep -Po "(?<= $prop=\")[^\"]*")"
-  if [ -n "$sterm" ] && [ "$(echo "$match" | wc -l)" -gt 1 ]; then
-    echo "multiple matches tosearch"
-    echo "prop $prop"
-    echo "sterm $sterm"
-    echo "match $match"
+md_query_token() {
+  local token="$1"
+  local devices
+  local status
+
+  devices="$(/usr/bin/sudo /sbin/blkid -t "$token" -o device)"
+  status=$?
+  if (( status == 0 )); then
+    if [[ -z "$devices" ]]; then
+      echo "ERROR: blkid succeeded but returned no device for $token" >&2
+      return 2
+    fi
+    printf '%s\n' "$devices"
+    return 0
   fi
-  echo "$match"
+
+  # blkid returns 2 when no device matches a token.
+  if (( status == 2 )) && [[ -z "$devices" ]]; then
+    return 1
+  fi
+
+  echo "ERROR: blkid failed while resolving $token (status $status)" >&2
+  return 2
 }
 
-blkln() { 
-  sterm=$1
-  match="$(sudo /sbin/blkid | grep "\"$sterm\"")"
-  echo "$match"
+md_resolve_label() {
+  local label="$1"
+  local label_devices
+  local label_status
+  local partlabel_devices
+  local partlabel_status
+  local devices
+  local device
+  local count
+  local candidate
+  local actual_label
+
+  MD_DEVICE=""
+  MD_LABEL_KEY=""
+  if [[ -z "$label" ]]; then
+    echo "ERROR: refusing to resolve an empty disk label" >&2
+    return 2
+  fi
+
+  label_devices="$(md_query_token "LABEL=$label")"
+  label_status=$?
+  (( label_status == 2 )) && return 2
+
+  partlabel_devices="$(md_query_token "PARTLABEL=$label")"
+  partlabel_status=$?
+  (( partlabel_status == 2 )) && return 2
+
+  if (( label_status == 1 && partlabel_status == 1 )); then
+    return 1
+  fi
+
+  devices="$({ printf '%s\n' "$label_devices"; printf '%s\n' "$partlabel_devices"; } \
+    | /usr/bin/awk 'NF && !seen[$0]++')"
+  count="$(printf '%s\n' "$devices" | /usr/bin/awk 'NF { count++ } END { print count + 0 }')"
+  if (( count != 1 )); then
+    echo "ERROR: exact label '$label' resolves to $count devices; refusing" >&2
+    printf '%s\n' "$devices" >&2
+    return 2
+  fi
+
+  device="$(printf '%s\n' "$devices" | /usr/bin/awk 'NF { print; exit }')"
+  device="$(/usr/bin/readlink -f -- "$device")"
+  if [[ -z "$device" || ! -b "$device" ]]; then
+    echo "ERROR: resolved device for '$label' is not a block device" >&2
+    return 2
+  fi
+
+  MD_LABEL_KEY="PARTLABEL"
+  while IFS= read -r candidate; do
+    if [[ -n "$candidate" && "$(/usr/bin/readlink -f -- "$candidate")" == "$device" ]]; then
+      MD_LABEL_KEY="LABEL"
+      break
+    fi
+  done <<< "$label_devices"
+
+  actual_label="$(/usr/bin/sudo /sbin/blkid -s "$MD_LABEL_KEY" -o value -- "$device")"
+  if [[ $? -ne 0 || "$actual_label" != "$label" ]]; then
+    echo "ERROR: $device no longer has exact $MD_LABEL_KEY '$label'; refusing" >&2
+    return 2
+  fi
+
+  MD_DEVICE="$device"
+  return 0
+}
+
+md_parent_disk() {
+  local device="$1"
+  local ancestors
+  local status
+  local disks
+  local count
+
+  ancestors="$(/usr/bin/lsblk -s -nrpo NAME,TYPE -- "$device")"
+  status=$?
+  if (( status != 0 )) || [[ -z "$ancestors" ]]; then
+    echo "ERROR: cannot determine parent disk for $device" >&2
+    return 1
+  fi
+
+  disks="$(printf '%s\n' "$ancestors" \
+    | /usr/bin/awk '$2 == "disk" && !seen[$1]++ { print $1 }')"
+  count="$(printf '%s\n' "$disks" | /usr/bin/awk 'NF { count++ } END { print count + 0 }')"
+  if (( count != 1 )); then
+    echo "ERROR: expected one parent disk for $device, found $count" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$disks"
 }
 
 mntdsk() {
-  label=$1
-  pth="/mnt/$label"
-  match=$(blkln $label)
-  unset msg
-  if [ -z "$match" ]; then
-    msg="no blkid match for: $label"
-  elif [[ "$match" == *"ro,"* ]]; then
-    msg="read-only match for: $label"
-  elif [[ "$(grep "dev/sd" /proc/mounts)" == *"/mnt/$label"* ]]; then
-    msg="already mounted for: $label"
-  fi
-  echo "$msg"
-  if [ -n "$msg" ]; then return 0; fi
-  
+  local label="$1"
+  local pth="/mnt/$label"
+  local resolve_status
+  local device
+  local label_key
+  local mount_targets
+  local read_only
+  local fstype
+  local root_source
+  local root_disk
+  local device_disk
+  local actual_label
+  local mounted_target
+  local -a mount_opts=()
 
-  uuid=$(fetch_uuid $label)
-  fstype=$(fsprop TYPE $label)
-  
-  mkdir "$pth" 2>/dev/null
-  sudo chown pi $pth
-  sudo chmod 777 $pth 
-  # /sbin/blkid | grep mmcblk0p | grep $uuid && echo "not mounting $label because it is mmcfs" && return 1
-  if [ -n "$uuid" ]; then
-    fsroot=$(df -h | grep /boot | perl -pe 's|\d.*||g')
-    /sbin/blkid | grep -P "$fsroot" && echo "not mounting $label because it is rootFS: $fsroot" && return 1
-    fstype=$(fsprop TYPE $uuid)
-    
-    echo "running sudo mount -U $uuid -t $fstype $opts $pth"
-    sudo mount -U $uuid -t $fstype $opts $pth
-  elif [ -n "$fstype" ]; then
-    if [[ "$fstype" == "hfsplus" ]]; then opts="-o force,rw"; else opts=""; fi
-    if [[ "$fstype" == "exfat" ]]; then sudo modprobe fuse; fi
-    mountkey=PARTLABEL
-    if [ -z "$(fsprop $mountkey $label)" ]; then mountkey=LABEL; fi
-    echo "running sudo mount $mountkey=$label -t $fstype $opts $pth"
-    sudo mount $mountkey=$label -t $fstype $opts $pth
+  md_resolve_label "$label"
+  resolve_status=$?
+  if (( resolve_status == 1 )); then
+    echo "no exact LABEL or PARTLABEL match for: $label"
+    return 0
+  elif (( resolve_status != 0 )); then
+    return 1
   fi
-  # echo "mounted $label at $pth"
+  device="$MD_DEVICE"
+  label_key="$MD_LABEL_KEY"
+
+  mount_targets="$(/usr/bin/findmnt -rn -S "$device" -o TARGET)"
+  if [[ -n "$mount_targets" ]]; then
+    if [[ "$mount_targets" == "$pth" ]]; then
+      echo "already mounted for: $label ($device)"
+      return 0
+    fi
+    echo "ERROR: $device is already mounted somewhere other than $pth: $mount_targets" >&2
+    return 1
+  fi
+
+  read_only="$(/usr/bin/lsblk -dnro RO -- "$device")"
+  if [[ $? -ne 0 || ! "$read_only" =~ ^[01]$ ]]; then
+    echo "ERROR: cannot determine read-only state for $device" >&2
+    return 1
+  elif [[ "$read_only" == "1" ]]; then
+    echo "ERROR: refusing to mount read-only device for: $label ($device)" >&2
+    return 1
+  fi
+
+  root_source="$(/usr/bin/findmnt -rn -T / -o SOURCE)"
+  if [[ $? -ne 0 || -z "$root_source" ]]; then
+    echo "ERROR: cannot determine root filesystem source; refusing to mount $label" >&2
+    return 1
+  fi
+  root_disk="$(md_parent_disk "$root_source")" || return 1
+  device_disk="$(md_parent_disk "$device")" || return 1
+  if [[ "$root_disk" == "$device_disk" ]]; then
+    echo "ERROR: refusing to mount $label from root disk $root_disk" >&2
+    return 1
+  fi
+
+  fstype="$(/usr/bin/sudo /sbin/blkid -s TYPE -o value -- "$device")"
+  if [[ $? -ne 0 || -z "$fstype" ]]; then
+    echo "ERROR: cannot determine filesystem type for $label ($device)" >&2
+    return 1
+  fi
+
+  if [[ "$fstype" == "hfsplus" ]]; then
+    mount_opts=(-o force,rw)
+  elif [[ "$fstype" == "exfat" ]]; then
+    /usr/bin/sudo /usr/sbin/modprobe fuse || return 1
+  fi
+
+  /usr/bin/sudo /usr/bin/install -d -m 0777 -o pi -g pi -- "$pth" || return 1
+  mounted_target="$(/usr/bin/findmnt -rn -T "$pth" -o TARGET 2>/dev/null)"
+  if [[ "$mounted_target" == "$pth" ]]; then
+    echo "ERROR: $pth became a mount point before mounting $device; refusing" >&2
+    return 1
+  fi
+
+  # Close the discovery-to-mount race by checking the selected exact label again.
+  actual_label="$(/usr/bin/sudo /sbin/blkid -s "$label_key" -o value -- "$device")"
+  if [[ $? -ne 0 || "$actual_label" != "$label" || ! -b "$device" ]]; then
+    echo "ERROR: $device no longer has exact $label_key '$label'; refusing" >&2
+    return 1
+  fi
+
+  echo "mounting exact $label_key '$label' from $device at $pth"
+  /usr/bin/sudo /usr/bin/mount -t "$fstype" "${mount_opts[@]}" -- "$device" "$pth" || return 1
+
+  mounted_target="$(/usr/bin/findmnt -rn -S "$device" -o TARGET)"
+  if [[ "$mounted_target" != "$pth" ]]; then
+    echo "ERROR: mount command succeeded but $device is not mounted at $pth" >&2
+    return 1
+  fi
+  echo "mounted $label at $pth"
 }
 
 rm_mnt_dir() { # prevent Time Machine from backing up onto SD card etc
-  diskdir="$1"
+  local diskdir="$1"
+  local resolve_status
 
   # fail closed: this deleted the mounted TM disk on 2026-07-14 when bare
   # `blkid` wasn't in pi's SSH PATH → empty output looked like "disk absent"
-  if grep -q " /mnt/$diskdir " /proc/mounts; then
+  if /usr/bin/grep -q " /mnt/$diskdir " /proc/mounts; then
     echo "NOT removing mount dir /mnt/$diskdir: currently mounted"
     return 0
   fi
 
-  attached="$(sudo /sbin/blkid)"
-  if [ -z "$attached" ]; then
-    echo "ERROR: blkid empty/failed, refusing to remove /mnt/$diskdir"
+  md_resolve_label "$diskdir"
+  resolve_status=$?
+  if (( resolve_status == 0 )); then
+    echo "NOT removing mount dir /mnt/$diskdir for attached disk $MD_DEVICE"
+    return 0
+  elif (( resolve_status != 1 )); then
+    echo "ERROR: disk discovery failed, refusing to remove /mnt/$diskdir"
     return 1
   fi
-  if echo "$attached" | grep -q "$diskdir"; then
-    echo "NOT removing mount dir /mnt/$diskdir for attached disk"
-    return 0
-  fi
 
-  [ -d "/mnt/$diskdir" ] || return 0
-  echo "removing mount dir because not in blkid: /mnt/$diskdir"
+  [[ -d "/mnt/$diskdir" ]] || return 0
+  echo "removing empty mount dir because no exact label is attached: /mnt/$diskdir"
   # rmdir only: a decoy dir is always empty; anything non-empty is real data
-  rmdir "/mnt/$diskdir" || echo "ERROR: /mnt/$diskdir has contents, refusing to delete"
+  /usr/bin/rmdir -- "/mnt/$diskdir" \
+    || echo "ERROR: /mnt/$diskdir has contents, refusing to delete"
 }
 
 if [[ "$#" = "1" ]]; then
@@ -105,15 +258,13 @@ elif [[ "$#" = "0" ]]; then # used by minutely cron job
   # mntdsk mbbackup
   # mntdsk bigboi
 
-  # mntdsk msd_nand2_boot && mntdsk msd_nand2 && mntdsk msd_nand2_settings
-  # mntdsk msd_nand1_boot && mntdsk msd_nand1 && mntdsk msd_nand1_settings
 fi
 
 
 . /home/pi/scripts/fix_hfs_fs.sh 
 
 echo "mounted disks:"
-grep "dev/sd" /proc/mounts
+/usr/bin/grep "dev/sd" /proc/mounts
 
 # 
 # 
@@ -124,4 +275,3 @@ grep "dev/sd" /proc/mounts
 # 
 # It is also possible to set the filesystem label using the -L option of tune2fs, enter:
 # # tune2fs -L usbstroage /dev/sdb2
-

--- a/pi/scripts/ntfy_send.sh
+++ b/pi/scripts/ntfy_send.sh
@@ -13,5 +13,7 @@ tags=${4:-}
 args=(-H "Title: $title" -H "Priority: $prio")
 [ -n "$tags" ] && args+=(-H "Tags: $tags")
 
-curl -fsS -m 15 "${args[@]}" -d "$msg" "$url" >/dev/null \
-  || echo "ntfy_send failed ($url): $title — $msg"
+if ! /usr/bin/curl -fsS -m 15 "${args[@]}" -d "$msg" "$url" >/dev/null; then
+  echo "ntfy_send failed: $title" >&2
+  exit 1
+fi

--- a/pi/scripts/umount_disks.sh
+++ b/pi/scripts/umount_disks.sh
@@ -1,45 +1,526 @@
-#! /bin/bash
+#!/bin/bash
 
-if [[ "$#" = "1" ]]
-  then disk_name=$1
-else
-  unset disk_name
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=disk_policy.sh
+if ! . "$script_dir/disk_policy.sh"; then
+  echo "ERROR: cannot load $script_dir/disk_policy.sh" >&2
+  return 1 2>/dev/null || exit 1
 fi
 
-# stop any running backup/restore gracefully before pulling mounts (no-op when idle)
-sudo /home/pi/scripts/backup/abort_backup.sh
+UD_DEVICE=
+UD_PARENT=
+UD_MOUNTS=
+UD_FAST_DEVICE=
+UD_FAST_PARENT=
+UD_FAST_DISKSEQ=
+UD_FAILURES=()
+UD_STATE_DIR=/run/lock/vanpi-hdd-spindown
 
-kill_torrent_client() {
-  if [[ "$(ps ax)" == *"qbittorrent"* ]]; then echo 'killtorrent' && sudo pkill -TERM qbittorrent && sleep 4; fi
-  if [[ "$(ps ax)" == *"qbittorrent"* ]]; then echo 'SECOND ATTEMPT killtorrent' && sudo pkill -f qbittorrent && sleep 3; fi
+ud_usage() {
+  echo "usage: ${0##*/} [--dry-run] [--spindown] [label]" >&2
+  echo "       ${0##*/} --clear-spindown-state" >&2
 }
 
-hdd_locations() { 
-  if [ -z ${disk_name+x} ]; then
-    cat /proc/self/mounts | grep -Po "/mnt/[^ ]+" | grep -vP 'usb|msd|EXFAT512'
+# Build an identity using only udev symlinks and sysfs.  Unlike blkid, this
+# does not issue reads to a sleeping disk.  diskseq changes when a block device
+# is disconnected and another device later reuses the same /dev/sdX name.
+ud_fast_identity() {
+  local label=$1 label_link block sys_path parent
+
+  UD_FAST_DEVICE=
+  UD_FAST_PARENT=
+  UD_FAST_DISKSEQ=
+  label_link="/dev/disk/by-label/$label"
+  [[ -d /dev/disk/by-label && -e "$label_link" ]] || return 1
+
+  UD_FAST_DEVICE=$(/usr/bin/readlink -f -- "$label_link") || return 1
+  [[ -b "$UD_FAST_DEVICE" ]] || return 1
+  block=${UD_FAST_DEVICE##*/}
+  [[ -e "/sys/class/block/$block" ]] || return 1
+
+  if [[ -f "/sys/class/block/$block/partition" ]]; then
+    sys_path=$(/usr/bin/readlink -f -- "/sys/class/block/$block") || return 1
+    parent=${sys_path%/*}
+    parent=${parent##*/}
   else
-    cat /proc/self/mounts | grep -Po "/mnt/${disk_name}[^_]"
+    parent=$block
+  fi
+  [[ -e "/sys/class/block/$parent/diskseq" ]] || return 1
+
+  UD_FAST_PARENT="/dev/$parent"
+  IFS= read -r UD_FAST_DISKSEQ < "/sys/class/block/$parent/diskseq" || return 1
+  [[ -n "$UD_FAST_DISKSEQ" ]]
+}
+
+ud_remove_spindown_state() {
+  local label=$1 marker="$UD_STATE_DIR/$label"
+  if [[ -e "$marker" ]]; then
+    /usr/bin/rm -f -- "$marker" || return 1
+  fi
+  return 0
+}
+
+ud_clear_spindown_state() {
+  local label
+  if [[ -e "$UD_STATE_DIR" && ! -d "$UD_STATE_DIR" ]]; then
+    ud_record_failure "$UD_STATE_DIR exists but is not a directory"
+    return 1
+  fi
+  for label in "${HDD_LABELS[@]}"; do
+    ud_remove_spindown_state "$label" || return 1
+  done
+  [[ -d "$UD_STATE_DIR" ]] && /usr/bin/rmdir -- "$UD_STATE_DIR" 2>/dev/null || true
+}
+
+ud_spindown_state_is_current() {
+  local label=$1 marker="$UD_STATE_DIR/$label" stored mounts rc
+  [[ -f "$marker" ]] || return 1
+  ud_fast_identity "$label" || {
+    ud_remove_spindown_state "$label"
+    return 1
+  }
+  IFS= read -r stored < "$marker" || {
+    ud_remove_spindown_state "$label"
+    return 1
+  }
+  if [[ "$stored" != "$UD_FAST_DEVICE $UD_FAST_PARENT $UD_FAST_DISKSEQ" ]]; then
+    ud_remove_spindown_state "$label"
+    return 1
+  fi
+
+  # A manual remount invalidates the state even if the hardware is unchanged.
+  mounts=$(/usr/bin/findmnt -rn -S "$UD_FAST_DEVICE" -o TARGET 2>&1)
+  rc=$?
+  if (( rc == 1 )) && [[ -z "$mounts" ]]; then
+    return 0
+  fi
+  ud_remove_spindown_state "$label"
+  return 1
+}
+
+ud_write_spindown_state() {
+  local label=$1 expected_device=$2 expected_parent=$3 marker tmp
+  ud_fast_identity "$label" || {
+    ud_record_failure "cannot build non-probing spindown identity for $label"
+    return 1
+  }
+  if [[ "$UD_FAST_DEVICE" != "$expected_device" || "$UD_FAST_PARENT" != "$expected_parent" ]]; then
+    ud_record_failure "$label device identity changed while recording spindown state"
+    return 1
+  fi
+
+  if [[ -e "$UD_STATE_DIR" && ! -d "$UD_STATE_DIR" ]]; then
+    ud_record_failure "$UD_STATE_DIR exists but is not a directory"
+    return 1
+  fi
+  /usr/bin/install -d -m 700 "$UD_STATE_DIR" || {
+    ud_record_failure "cannot create $UD_STATE_DIR"
+    return 1
+  }
+  marker="$UD_STATE_DIR/$label"
+  tmp="$UD_STATE_DIR/.$label.$$"
+  if ! (umask 077; printf '%s %s %s\n' \
+      "$UD_FAST_DEVICE" "$UD_FAST_PARENT" "$UD_FAST_DISKSEQ" > "$tmp"); then
+    ud_record_failure "cannot write spindown state for $label"
+    return 1
+  fi
+  if ! /usr/bin/mv -f -- "$tmp" "$marker"; then
+    /usr/bin/rm -f -- "$tmp"
+    ud_record_failure "cannot install spindown state for $label"
+    return 1
   fi
 }
 
-locs=`hdd_locations`
-echo "$locs"
-if [ -n "$(echo $locs | grep -Po movingparts)" ]; then
-  kill_torrent_client
+ud_record_failure() {
+  local message=$1
+  echo "ERROR: $message" >&2
+  UD_FAILURES+=("$message")
+}
+
+ud_is_hdd_label() {
+  local wanted=$1 label
+  for label in "${HDD_LABELS[@]}"; do
+    [[ "$label" == "$wanted" ]] && return 0
+  done
+  return 1
+}
+
+# Set UD_PARENT to the one whole-disk ancestor of a block device.
+ud_find_parent_disk() {
+  local device=$1 ancestry name type extra
+  local -a parents=()
+
+  ancestry=$(/usr/bin/lsblk -s -nrpo NAME,TYPE "$device" 2>&1) || {
+    ud_record_failure "lsblk failed for $device: $ancestry"
+    return 1
+  }
+  while read -r name type extra; do
+    [[ "$type" == "disk" ]] && parents+=("$name")
+  done <<< "$ancestry"
+
+  if (( ${#parents[@]} != 1 )); then
+    ud_record_failure "$device has ${#parents[@]} whole-disk ancestors; expected exactly one"
+    return 1
+  fi
+  UD_PARENT=${parents[0]}
+}
+
+# Resolve an exact filesystem label and validate its physical parent.
+# Returns 0 when present, 1 when safely absent, and 2 on a discovery error.
+ud_resolve_label() {
+  local label=$1 label_link query rc actual_label transport root_source root_parent
+  local -a devices=()
+
+  UD_DEVICE=
+  UD_PARENT=
+  UD_MOUNTS=
+
+  label_link="/dev/disk/by-label/$label"
+  if [[ ! -d /dev/disk/by-label ]]; then
+    ud_record_failure "/dev/disk/by-label is unavailable; refusing disk discovery"
+    return 2
+  elif [[ ! -e "$label_link" ]]; then
+    return 1
+  fi
+
+  query=$(/usr/bin/sudo /sbin/blkid -t "LABEL=$label" -o device 2>&1)
+  rc=$?
+  if (( rc == 2 )) && [[ -z "$query" ]]; then
+    ud_record_failure "udev reports label $label at $label_link but blkid found no matching filesystem"
+    return 2
+  elif (( rc != 0 )); then
+    ud_record_failure "blkid lookup for label $label failed (status $rc): $query"
+    return 2
+  fi
+
+  while IFS= read -r device; do
+    [[ -n "$device" ]] && devices+=("$device")
+  done <<< "$query"
+  if (( ${#devices[@]} != 1 )); then
+    ud_record_failure "label $label resolved to ${#devices[@]} devices; expected exactly one"
+    return 2
+  fi
+
+  UD_DEVICE=$(/usr/bin/readlink -f -- "${devices[0]}") || {
+    ud_record_failure "cannot resolve ${devices[0]} for label $label"
+    return 2
+  }
+  if [[ ! -b "$UD_DEVICE" ]]; then
+    ud_record_failure "label $label resolved to non-block device $UD_DEVICE"
+    return 2
+  fi
+
+  actual_label=$(/usr/bin/sudo /sbin/blkid -s LABEL -o value "$UD_DEVICE" 2>&1) || {
+    ud_record_failure "cannot verify label on $UD_DEVICE: $actual_label"
+    return 2
+  }
+  if [[ "$actual_label" != "$label" ]]; then
+    ud_record_failure "$UD_DEVICE label changed during discovery (expected $label, got $actual_label)"
+    return 2
+  fi
+
+  ud_find_parent_disk "$UD_DEVICE" || return 2
+  transport=$(/usr/bin/lsblk -dnro TRAN "$UD_PARENT" 2>&1) || {
+    ud_record_failure "cannot determine transport for $UD_PARENT: $transport"
+    return 2
+  }
+  if [[ "$transport" != "usb" ]]; then
+    ud_record_failure "refusing label $label on non-USB parent $UD_PARENT (transport=${transport:-unknown})"
+    return 2
+  fi
+
+  root_source=$(/usr/bin/findmnt -nro SOURCE / 2>&1) || {
+    ud_record_failure "cannot identify the root filesystem source: $root_source"
+    return 2
+  }
+  root_source=$(/usr/bin/readlink -f -- "$root_source") || {
+    ud_record_failure "cannot resolve root filesystem source $root_source"
+    return 2
+  }
+  ud_find_parent_disk "$root_source" || return 2
+  root_parent=$UD_PARENT
+  ud_find_parent_disk "$UD_DEVICE" || return 2
+  if [[ "$UD_PARENT" == "$root_parent" ]]; then
+    ud_record_failure "refusing label $label because $UD_PARENT contains the root filesystem"
+    return 2
+  fi
+
+  UD_MOUNTS=$(/usr/bin/findmnt -rn -S "$UD_DEVICE" -o TARGET 2>&1)
+  rc=$?
+  if (( rc == 1 )) && [[ -z "$UD_MOUNTS" ]]; then
+    UD_MOUNTS=
+  elif (( rc != 0 )); then
+    ud_record_failure "findmnt failed for $UD_DEVICE (status $rc): $UD_MOUNTS"
+    return 2
+  fi
+  return 0
+}
+
+# Return success only when no partition on a parent disk is mounted.
+ud_parent_is_unmounted() {
+  local parent=$1 nodes rc node mounts
+
+  nodes=$(/usr/bin/lsblk -nrpo NAME "$parent" 2>&1) || {
+    ud_record_failure "cannot enumerate block devices below $parent: $nodes"
+    return 1
+  }
+  while IFS= read -r node; do
+    [[ -n "$node" ]] || continue
+    mounts=$(/usr/bin/findmnt -rn -S "$node" -o TARGET 2>&1)
+    rc=$?
+    if (( rc == 0 )); then
+      ud_record_failure "refusing to spin down $parent: $node is still mounted at $mounts"
+      return 1
+    elif (( rc != 1 )); then
+      ud_record_failure "findmnt failed while checking $node (status $rc): $mounts"
+      return 1
+    fi
+  done <<< "$nodes"
+  return 0
+}
+
+ud_kill_torrent_client() {
+  local rc attempt
+  /usr/bin/pgrep -f '[q]bittorrent-nox' >/dev/null 2>&1
+  rc=$?
+  (( rc == 1 )) && return 0
+  (( rc == 0 )) || return 1
+
+  echo "asking qbittorrent-nox to stop"
+  /usr/bin/sudo /usr/bin/pkill -TERM -f '[q]bittorrent-nox'
+  rc=$?
+  (( rc <= 1 )) || return 1
+
+  # This Pi's qBittorrent can need about 18 seconds to save state and exit.
+  # Keep the stop graceful, but bound ignition shutdown at 30 seconds.
+  for attempt in {1..30}; do
+    /usr/bin/pgrep -f '[q]bittorrent-nox' >/dev/null 2>&1
+    rc=$?
+    (( rc == 1 )) && return 0
+    (( rc == 0 )) || return 1
+    sleep 1
+  done
+  return 1
+}
+
+ud_notify_failures() {
+  local should_notify=$1 summary
+  (( should_notify )) || return 0
+  (( ${#UD_FAILURES[@]} )) || return 0
+  summary=$(IFS='; '; echo "${UD_FAILURES[*]}")
+  /home/pi/scripts/ntfy_send.sh \
+    "vanpi HDD shutdown failed" "$summary" high warning || true
+}
+
+umount_disks_main() {
+  local dry_run=0 spindown=0 clear_state=0 explicit_label= label arg rc expected_mount target
+  local post_mounts
+  local parent_name hd_idle_output
+  local needs_torrent_stop=0 had_preflight_failure=0 had_runtime_failure=0
+  local -a labels=() attached_labels=() mounted_labels=()
+  local -A devices=() parents=() mounts=() unmount_failed=() spun_parents=()
+
+  while (( $# )); do
+    arg=$1
+    shift
+    case "$arg" in
+      --dry-run) dry_run=1 ;;
+      --spindown) spindown=1 ;;
+      --clear-spindown-state) clear_state=1 ;;
+      --help|-h) ud_usage; return 0 ;;
+      --*) ud_usage; return 2 ;;
+      *)
+        if [[ -n "$explicit_label" ]]; then
+          ud_usage
+          return 2
+        fi
+        explicit_label=$arg
+        ;;
+    esac
+  done
+
+  if (( clear_state )); then
+    if (( dry_run || spindown )) || [[ -n "$explicit_label" ]]; then
+      ud_usage
+      return 2
+    fi
+    ud_clear_spindown_state
+    return $?
+  fi
+
+  if [[ -n "$explicit_label" ]]; then
+    labels=("$explicit_label")
+    if (( spindown )) && ! ud_is_hdd_label "$explicit_label"; then
+      ud_record_failure "refusing to spin down label $explicit_label because it is not in HDD_LABELS"
+      ud_notify_failures "$(( spindown && ! dry_run ))"
+      return 1
+    fi
+  else
+    labels=("${HDD_LABELS[@]}")
+  fi
+
+  # Complete all discovery and mountpoint validation before changing anything.
+  for label in "${labels[@]}"; do
+    if (( spindown )) && ud_spindown_state_is_current "$label"; then
+      echo "$label: already stopped on $UD_FAST_PARENT; skipping disk probe"
+      continue
+    fi
+
+    ud_resolve_label "$label"
+    rc=$?
+    if (( rc == 1 )); then
+      echo "$label: not attached"
+      continue
+    elif (( rc != 0 )); then
+      had_preflight_failure=1
+      continue
+    fi
+
+    devices[$label]=$UD_DEVICE
+    parents[$label]=$UD_PARENT
+    mounts[$label]=$UD_MOUNTS
+    attached_labels+=("$label")
+    expected_mount="/mnt/$label"
+
+    if [[ -n "$UD_MOUNTS" ]]; then
+      while IFS= read -r target; do
+        [[ -n "$target" ]] || continue
+        if [[ "$target" != "$expected_mount" ]]; then
+          ud_record_failure "$label is mounted at unexpected target $target (expected $expected_mount)"
+          had_preflight_failure=1
+        fi
+      done <<< "$UD_MOUNTS"
+      mounted_labels+=("$label")
+      [[ "$label" == "movingparts" ]] && needs_torrent_stop=1
+    fi
+  done
+
+  if (( had_preflight_failure )); then
+    echo "refusing all disk changes because preflight validation failed" >&2
+    ud_notify_failures "$(( spindown && ! dry_run ))"
+    return 1
+  fi
+
+  if (( spindown && ${#attached_labels[@]} )) && [[ ! -x /usr/sbin/hd-idle ]]; then
+    ud_record_failure "/usr/sbin/hd-idle is unavailable; refusing ignition disk shutdown"
+    ud_notify_failures "$(( spindown && ! dry_run ))"
+    return 1
+  fi
+
+  for label in "${attached_labels[@]}"; do
+    if [[ -n "${mounts[$label]}" ]]; then
+      echo "$label: ${devices[$label]} -> ${mounts[$label]}; parent=${parents[$label]}; action=unmount$([[ $spindown == 1 ]] && echo '+spindown')"
+    else
+      echo "$label: ${devices[$label]} is unmounted; parent=${parents[$label]}; action=$([[ $spindown == 1 ]] && echo spindown || echo none)"
+    fi
+  done
+  if (( dry_run )); then
+    echo "dry run: no services, mounts, or disks were changed"
+    return 0
+  fi
+
+  if (( ${#mounted_labels[@]} )); then
+    if ! /usr/bin/sudo /home/pi/scripts/backup/abort_backup.sh; then
+      ud_record_failure "backup/restore did not stop; refusing to unmount HDDs"
+      ud_notify_failures "$(( spindown && ! dry_run ))"
+      return 1
+    fi
+
+    if (( needs_torrent_stop )) && ! ud_kill_torrent_client; then
+      ud_record_failure "qbittorrent-nox did not stop; refusing to unmount HDDs"
+      ud_notify_failures "$(( spindown && ! dry_run ))"
+      return 1
+    fi
+
+    if ! /usr/bin/sudo /usr/sbin/service smbd stop; then
+      ud_record_failure "smbd did not stop; refusing to unmount HDDs"
+      ud_notify_failures "$(( spindown && ! dry_run ))"
+      return 1
+    fi
+  fi
+
+  for label in "${mounted_labels[@]}"; do
+    expected_mount="/mnt/$label"
+    echo "unmounting $label from $expected_mount"
+    if ! /usr/bin/sudo /usr/bin/umount -- "$expected_mount"; then
+      ud_record_failure "normal unmount failed for $label at $expected_mount"
+      unmount_failed[$label]=1
+      had_runtime_failure=1
+      continue
+    fi
+
+    post_mounts=$(/usr/bin/findmnt -rn -S "${devices[$label]}" -o TARGET 2>&1)
+    rc=$?
+    if (( rc == 0 )); then
+      ud_record_failure "$label still has a mount after umount returned success"
+      unmount_failed[$label]=1
+      had_runtime_failure=1
+    elif (( rc != 1 )); then
+      ud_record_failure "cannot verify $label after unmount (findmnt status $rc): $post_mounts"
+      unmount_failed[$label]=1
+      had_runtime_failure=1
+    fi
+  done
+
+  if (( spindown )); then
+    for label in "${attached_labels[@]}"; do
+      [[ -z "${unmount_failed[$label]:-}" ]] || continue
+
+      # Re-resolve immediately before the destructive device command and ensure
+      # USB enumeration did not change under us.
+      ud_resolve_label "$label"
+      rc=$?
+      if (( rc != 0 )); then
+        [[ $rc == 1 ]] && ud_record_failure "$label disappeared before spindown"
+        had_runtime_failure=1
+        continue
+      fi
+      if [[ "$UD_DEVICE" != "${devices[$label]}" || "$UD_PARENT" != "${parents[$label]}" ]]; then
+        ud_record_failure "$label device mapping changed before spindown; refusing it"
+        had_runtime_failure=1
+        continue
+      fi
+      if [[ -n "$UD_MOUNTS" ]]; then
+        ud_record_failure "$label was remounted at $UD_MOUNTS before spindown"
+        had_runtime_failure=1
+        continue
+      fi
+      [[ -z "${spun_parents[$UD_PARENT]:-}" ]] || continue
+      if ! ud_parent_is_unmounted "$UD_PARENT"; then
+        had_runtime_failure=1
+        continue
+      fi
+
+      # Debian Bookworm's hd-idle 1.05 prepends /dev/ to -t internally and can
+      # return zero even when it printed an open error, so pass only the kernel
+      # disk name and require both a zero status and no diagnostic output.
+      parent_name=${UD_PARENT##*/}
+      echo "spinning down $label on $UD_PARENT"
+      hd_idle_output=$(/usr/bin/sudo /usr/sbin/hd-idle -t "$parent_name" 2>&1)
+      rc=$?
+      if (( rc == 0 )) && [[ -z "$hd_idle_output" ]]; then
+        spun_parents[$UD_PARENT]=1
+        if ! ud_write_spindown_state "$label" "$UD_DEVICE" "$UD_PARENT"; then
+          had_runtime_failure=1
+        fi
+      else
+        ud_record_failure "hd-idle failed for $label on $UD_PARENT (status $rc): ${hd_idle_output:-no diagnostic output}"
+        had_runtime_failure=1
+      fi
+    done
+  fi
+
+  echo "mounted USB/SCSI filesystems after disk operation:"
+  /usr/bin/findmnt -rn -t ext4,exfat,hfsplus -o SOURCE,TARGET | /usr/bin/grep '^/dev/sd' || true
+
+  ud_notify_failures "$(( spindown && ! dry_run ))"
+  (( had_runtime_failure == 0 ))
+}
+
+umount_disks_main "$@"
+umount_disks_rc=$?
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  exit "$umount_disks_rc"
+else
+  return "$umount_disks_rc"
 fi
-
-if [[ -n "$locs" ]]; then 
-  sudo service smbd stop
-  echo "unmounting $locs"
-  sudo umount $locs
-fi
-
-locs=`hdd_locations`
-if [[ -n "$locs" ]]; then 
-  echo "forcefully unmounting $locs"
-  sudo umount $locs -fl
-fi
-
-echo "mounted disks:"
-grep "dev/sd" /proc/mounts
-

--- a/pi/scripts/umount_disks.sh
+++ b/pi/scripts/umount_disks.sh
@@ -308,8 +308,13 @@ ud_notify_failures() {
   (( should_notify )) || return 0
   (( ${#UD_FAILURES[@]} )) || return 0
   summary=$(IFS='; '; echo "${UD_FAILURES[*]}")
-  /home/pi/scripts/ntfy_send.sh \
-    "vanpi HDD shutdown failed" "$summary" high warning || true
+  /home/pi/scripts/hdd_alert.sh failure "$summary" || true
+}
+
+ud_notify_recovery() {
+  local should_notify=$1
+  (( should_notify )) || return 0
+  /home/pi/scripts/hdd_alert.sh recovery || true
 }
 
 umount_disks_main() {
@@ -513,7 +518,11 @@ umount_disks_main() {
   echo "mounted USB/SCSI filesystems after disk operation:"
   /usr/bin/findmnt -rn -t ext4,exfat,hfsplus -o SOURCE,TARGET | /usr/bin/grep '^/dev/sd' || true
 
-  ud_notify_failures "$(( spindown && ! dry_run ))"
+  if (( had_runtime_failure )); then
+    ud_notify_failures "$(( spindown && ! dry_run ))"
+  else
+    ud_notify_recovery "$(( spindown && ! dry_run ))"
+  fi
   (( had_runtime_failure == 0 ))
 }
 

--- a/pi/sync_scripts.sh
+++ b/pi/sync_scripts.sh
@@ -39,7 +39,7 @@ services_pid=$!
 
 # RASPI — files grouped by destination, one scp per group
 scp $mux "$dsc/pi/.bashrc" "$dsc/pi/canbus_funcs.sh" "$dsc/pi/sns.sh" "$dsc/pi/keepalive.txt" \
-  "$configs/.bash_defaults" "$configs/.disk_uuids" \
+  "$configs/.bash_defaults" \
   "$configs/rsync-exclude-media.txt" \
   "$pi_ip:/home/pi/" &
 home_pid=$!


### PR DESCRIPTION
## Summary

- define an explicit `HDD_LABELS` allowlist for rotational USB disks
- resolve labels exactly, validate their USB parent disks, and refuse ambiguous or unsafe mappings
- stop backups, qBittorrent, and Samba before normal unmounts, then issue one-shot parent-disk spindown through `hd-idle`
- retain volatile per-device spindown state so the minutely ignition policy does not wake sleeping disks while probing them
- serialize the ignition hook and minutely policy loop, and fix qBittorrent backgrounding so it cannot retain the lifecycle lock
- keep `EXFAT512` outside the HDD policy and remove the forced/lazy unmount fallback
- send serious ignition-shutdown failures through `NTFY_MESSAGE_URL`, suppress an unchanged failure for 30 minutes, and send one recovery notification after a later successful shutdown
- make the generic ntfy sender report HTTP failures accurately without logging the secret URL or message body
- use the existing 55-second lifecycle-lock timeout as a stall canary, sending one diagnostic alert per stuck episode and one recovery after a later successful policy run
- retire the obsolete `.disk_uuids` map, its lookup helper, and the legacy `.bashrc` wrapper
- resolve mount targets by exact `LABEL`/`PARTLABEL`, refusing duplicates, discovery failures, and root-disk matches

## Why

The previous logic inferred HDDs from mountpoint-name exclusions and selected spindown targets from an effectively empty UUID list. Kernel rotational reporting is also unreliable for the attached USB flash drive. As a result, unmount classification was brittle and explicit platter spindown was not occurring.

This change makes HDD classification intentional and makes the entire unmount-to-spindown operation fail closed when discovery, service shutdown, backup coordination, or mount verification is incomplete. Those failures can leave an allowlisted HDD mounted or spinning, so the ignition path now reports them without generating a notification every minute.

Several commands performed while holding the lifecycle lock do not have explicit timeouts. Rather than immediately adding broad process termination behavior, the lock-timeout path now records whether any operation actually stalls long enough to block a later invocation.

The UUID map covered retired media and had become a second, stale identity system beside filesystem labels. Deleting it alone would have broken two consumers, so those consumers are removed or converted in the same change.

## Impact

When ignition is on, the listed HDD filesystems are normally unmounted and their validated parent disks are stopped. Flash and SD storage are not selected. When ignition turns off, transient spindown state is cleared before normal mounting resumes.

A real `--spindown` failure sends a high-priority warning through `NTFY_MESSAGE_URL`. The exact same failure is suppressed for 30 minutes; a changed failure is sent immediately. After a delivered failure, the next successful ignition shutdown sends one recovery message. Dry runs, ordinary manual unmounts, absent disks, and already-stopped disks do not create failure alerts.

If another `internet_switches.sh` instance cannot acquire the lifecycle lock within 55 seconds, it sends one high-priority diagnostic containing the recorded holder PID and age, lock state, a process tree without command arguments, and recent lifecycle log output. Further minutely alerts are suppressed until a later run acquires the lock and completes successfully, which sends one recovery notification. The canary observes only; it does not kill a process or bypass the lock.

The script requires `/usr/sbin/hd-idle` for ignition spindown and refuses the operation if it is unavailable. The independent `hd-idle` daemon is not used.

## Validation

- `bash -n` passed for all changed shell scripts
- `git diff --check` passed
- staged dry-runs on `vanpi` verified label, partition, parent-disk, and EXFAT exclusion behavior
- a real stopped-disk repeat check produced no additional block I/O
- a locked end-to-end test with qBittorrent active:
  - stopped qBittorrent gracefully
  - normally unmounted `movingparts` and `mbp2tbkup`
  - stopped the parent disks for `movingparts`, `bigboi`, and `mbp2tbkup`
  - left `EXFAT512` mounted
- the ignition-off policy remounted the HDD filesystems, restored Samba and qBittorrent, and released the lifecycle lock
- isolated loopback-only HDD alert tests verified first delivery, identical-failure suppression, one recovery delivery, marker cleanup, and nonzero status on transport failure without contacting the phone endpoint
- isolated loopback-only canary tests verified one stall delivery, duplicate suppression, secret-safe diagnostics, one recovery delivery, and marker cleanup
- after deployment, the next minutely lifecycle completed with the lock released and canary state clear
- deployed and repository file checksums matched
- the PR branch blob IDs and executable modes match the local files
- exact-label resolver checks on `vanpi` found the three attached targets uniquely, handled absent labels without mutation, and identified the SD root parent correctly
- deployed `mount_disks.sh` and `.bashrc` atomically under the lifecycle lock before removing `/home/pi/.disk_uuids` and `fetch_disk_uuid.sh`
- post-deploy checks confirmed unchanged mounts, no live legacy references, safe handling of mounted cleanup, and repository/live checksum agreement