### PR TITLE
Trigger vanpi policy from mwan3 events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ id_dsa
 .twilio/
 **/wireless
 vanrouter/etc
+!vanrouter/etc/
+vanrouter/etc/*
+!vanrouter/etc/mwan3.user
 *__pycache__*
 node_modules/
 **/node_modules/

--- a/pi/TODO.md
+++ b/pi/TODO.md
@@ -1,0 +1,46 @@
+# Vanpi lifecycle policy TODO
+
+## Event-driven policy migration
+
+- [ ] Put lifecycle reconciliation behind a `vanpi-policy.service` oneshot.
+  Keep policy decisions in an idempotent script; use systemd for execution,
+  serialization, status, and logging.
+  - The service now exists and is used by the OpenWrt mwan3 trigger. Existing
+    ignition and cron callers still invoke the policy script directly.
+
+- [ ] Change the existing ignition hooks to update ignition state and dispatch
+  `vanpi-policy.service` asynchronously. Ignition detection is already
+  event-driven through `ignitionmon.service`; this change should prevent the
+  monitor from blocking while disk and network actions complete.
+
+- [ ] Trigger policy reconciliation on disk attachment through udev and
+  systemd. Do not perform mounting, unmounting, or other long-running work in
+  the udev process itself.
+
+- [x] Trigger policy reconciliation from OpenWrt when mwan3 uplink state
+  changes. Pi-side NetworkManager cannot observe those transitions because the
+  Pi-to-router LAN connection remains up. The router notification should mean
+  only "reconcile now"; the Pi should then query mwan3 once for authoritative
+  current state.
+  - Use a dedicated, forced-command credential that can only request the
+    policy service; do not give the router general SSH access to the Pi or
+    other devices.
+  - Make the router hook non-blocking, bounded by a short timeout, and tolerant
+    of duplicate events.
+
+- [ ] Trigger reconciliation when the requested configuration changes. Prefer
+  having the configuration-writing command request the service; use a
+  systemd `.path` unit only as a fallback for changes made elsewhere.
+
+- [ ] Separate the user's requested configuration from the ignition override.
+  Derive effective policy from both inputs instead of replacing `mconf` with
+  `nodisk` and later restoring `mconf_last`.
+
+- [ ] Keep periodic reconciliation after event triggers are deployed. Replace
+  the minutely cron invocation only after event coverage is verified, then use
+  a slower systemd timer to recover from missed notifications and reboot
+  races.
+
+- [ ] Keep stall detection independent from the policy service. Starting an
+  already-active systemd oneshot does not create a second waiter, so a separate
+  watchdog must detect and report an abnormally long policy run.

--- a/pi/scripts/internet_switches.sh
+++ b/pi/scripts/internet_switches.sh
@@ -8,6 +8,9 @@ ISW_ALERT_FILE="$ISW_CANARY_DIR/alerted"
 ISW_ALERT_LOCK="$ISW_CANARY_DIR/alert.lock"
 ISW_LOG_FILE=${ISW_LOG_FILE:-/var/log/cron/internet_switches.log}
 ISW_NTFY_SEND=${ISW_NTFY_SEND:-/home/pi/scripts/ntfy_send.sh}
+ISW_MWAN_HOST=${ISW_MWAN_HOST:-root@OpenWrt}
+ISW_MWAN_TIMEOUT_SECONDS=${ISW_MWAN_TIMEOUT_SECONDS:-12}
+ISW_MWAN_STATE=""
 
 isw_prepare_canary_dir() {
   if [[ -L "$ISW_CANARY_DIR" || ( -e "$ISW_CANARY_DIR" && ! -d "$ISW_CANARY_DIR" ) ]]; then
@@ -283,9 +286,36 @@ kill_all() {
   unmount_drives
 }
 
-iface_online() { 
-  ifaces="$(ssh root@OpenWrt 'mwan3 interfaces')"
-  echo "$ifaces" | grep "interface $1 is online"
+refresh_mwan_state() {
+  local state
+  local status
+
+  state="$(/usr/bin/timeout --kill-after=2s "${ISW_MWAN_TIMEOUT_SECONDS}s" \
+    /usr/bin/ssh \
+      -n \
+      -o BatchMode=yes \
+      -o ConnectTimeout=5 \
+      -o ServerAliveInterval=3 \
+      -o ServerAliveCountMax=1 \
+      "$ISW_MWAN_HOST" \
+      '/usr/sbin/mwan3 interfaces' 2>&1)"
+  status=$?
+  if (( status != 0 )); then
+    echo "ERROR: unable to query mwan3 state from $ISW_MWAN_HOST (status $status)" >&2
+    printf '%s\n' "$state" >&2
+    return 1
+  fi
+  if [[ -z "$state" ]] || ! /usr/bin/grep -Fq 'Interface status:' <<< "$state"; then
+    echo "ERROR: mwan3 returned an empty or unrecognized interface report" >&2
+    return 1
+  fi
+
+  ISW_MWAN_STATE="$state"
+}
+
+iface_online() {
+  local interface="$1"
+  /usr/bin/grep -Fq " interface $interface is online" <<< "$ISW_MWAN_STATE"
 }
 
 # if date | grep '0:0'; then date; fi
@@ -294,10 +324,16 @@ set_isw_options() {
   echo ""
   echo "$(date)"
   if conf nodisk &> /dev/null; then kill_all # drives disabled ~/mconf/nodisk
-  elif iface_online clientwan &> /dev/null; then mobile_internet_ops
-  elif iface_online lifiwan &> /dev/null; then lifi_internet_ops
-  elif iface_online wan &> /dev/null; then ubnt_internet_ops
-  else no_internet_ops
+  else
+    # WAN transitions happen behind the Pi's stable LAN connection. OpenWrt
+    # pushes a reconciliation request, then the Pi verifies current mwan3
+    # state once here. A failed query is not evidence that every WAN is down.
+    refresh_mwan_state || return 1
+    if iface_online clientwan; then mobile_internet_ops
+    elif iface_online lifiwan; then lifi_internet_ops
+    elif iface_online wan; then ubnt_internet_ops
+    else no_internet_ops
+    fi
   fi
 }
 #

--- a/pi/scripts/setup_router_policy_trigger.sh
+++ b/pi/scripts/setup_router_policy_trigger.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -euo pipefail
+
+TRIGGER_USER=router-trigger
+TRIGGER_GROUP=router-trigger
+TRIGGER_HOME=/var/lib/router-trigger
+ROUTER_SOURCE_IP=192.168.6.1
+POLICY_UNIT=vanpi-policy.service
+AUTHORIZED_KEYS="$TRIGGER_HOME/.ssh/authorized_keys"
+SUDOERS_FILE=/etc/sudoers.d/router-trigger-vanpi-policy
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+if (( EUID != 0 )); then
+  fail "run this setup through sudo and provide the router public key on stdin"
+fi
+
+for required_path in \
+  /usr/bin/chmod \
+  /usr/bin/chown \
+  /usr/bin/cut \
+  /usr/bin/getent \
+  /usr/bin/install \
+  /usr/bin/mktemp \
+  /usr/bin/mv \
+  /usr/bin/rm \
+  /usr/bin/sudo \
+  /usr/bin/systemctl \
+  /usr/sbin/useradd \
+  /usr/sbin/usermod \
+  /usr/sbin/visudo
+do
+  [[ -x "$required_path" ]] || fail "required command is missing: $required_path"
+done
+
+IFS= read -r public_key || fail "no public key received on stdin"
+[[ -n "$public_key" ]] || fail "empty public key received on stdin"
+if IFS= read -r extra_line; then
+  fail "expected exactly one public-key line"
+fi
+
+read -r key_type key_blob _ <<< "$public_key"
+[[ "$key_type" == "ssh-ed25519" ]] || fail "only an Ed25519 trigger key is accepted"
+[[ "$key_blob" =~ ^[A-Za-z0-9+/]+={0,3}$ ]] || fail "malformed public-key body"
+
+if ! /usr/bin/getent passwd "$TRIGGER_USER" >/dev/null; then
+  /usr/sbin/useradd \
+    --system \
+    --user-group \
+    --home-dir "$TRIGGER_HOME" \
+    --create-home \
+    --shell /bin/sh \
+    "$TRIGGER_USER"
+fi
+
+account_entry="$(/usr/bin/getent passwd "$TRIGGER_USER")"
+account_home="$(/usr/bin/cut -d: -f6 <<< "$account_entry")"
+account_shell="$(/usr/bin/cut -d: -f7 <<< "$account_entry")"
+[[ "$account_home" == "$TRIGGER_HOME" ]] \
+  || fail "$TRIGGER_USER has unexpected home directory: $account_home"
+[[ "$account_shell" == "/bin/sh" ]] \
+  || fail "$TRIGGER_USER has unexpected shell: $account_shell"
+
+/usr/sbin/usermod --lock "$TRIGGER_USER"
+/usr/bin/install -d -m 0750 -o "$TRIGGER_USER" -g "$TRIGGER_GROUP" "$TRIGGER_HOME"
+/usr/bin/install -d -m 0700 -o "$TRIGGER_USER" -g "$TRIGGER_GROUP" "$TRIGGER_HOME/.ssh"
+
+auth_tmp=""
+sudoers_tmp=""
+cleanup() {
+  /usr/bin/rm -f -- "${auth_tmp:-}" "${sudoers_tmp:-}"
+}
+trap cleanup EXIT
+
+auth_tmp="$(/usr/bin/mktemp "$TRIGGER_HOME/.ssh/.authorized_keys.XXXXXX")"
+sudoers_tmp="$(/usr/bin/mktemp /etc/sudoers.d/.router-trigger-vanpi-policy.XXXXXX)"
+printf '%s %s %s %s\n' \
+  "from=\"$ROUTER_SOURCE_IP\",restrict,command=\"/usr/bin/sudo -n /usr/bin/systemctl start --no-block $POLICY_UNIT\"" \
+  "$key_type" \
+  "$key_blob" \
+  mwan3-policy-trigger > "$auth_tmp"
+/usr/bin/chown "$TRIGGER_USER:$TRIGGER_GROUP" "$auth_tmp"
+/usr/bin/chmod 0600 "$auth_tmp"
+
+printf '%s\n' \
+  "$TRIGGER_USER ALL=(root) NOPASSWD: /usr/bin/systemctl start --no-block $POLICY_UNIT" \
+  > "$sudoers_tmp"
+/usr/bin/chown root:root "$sudoers_tmp"
+/usr/bin/chmod 0440 "$sudoers_tmp"
+/usr/sbin/visudo -cf "$sudoers_tmp" >/dev/null
+/usr/bin/mv -f -- "$sudoers_tmp" "$SUDOERS_FILE"
+sudoers_tmp=""
+/usr/bin/mv -f -- "$auth_tmp" "$AUTHORIZED_KEYS"
+auth_tmp=""
+
+echo "installed restricted $TRIGGER_USER access for $POLICY_UNIT"

--- a/pi/services/vanpi-policy.service
+++ b/pi/services/vanpi-policy.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Reconcile vanpi network, disk, and torrent policy
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=pi
+WorkingDirectory=/home/pi
+Environment=HOME=/home/pi
+ExecStart=/home/pi/scripts/internet_switches.sh
+# internet_switches starts qBittorrent as a deliberately detached process.
+# Do not collect that process when this oneshot finishes.
+KillMode=process
+# Preserve the existing observe-only stall canary; do not terminate a disk
+# lifecycle operation at systemd's default service-start timeout.
+TimeoutStartSec=infinity
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=vanpi-policy
+
+[Install]
+WantedBy=multi-user.target

--- a/vanrouter/etc/mwan3.user
+++ b/vanrouter/etc/mwan3.user
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Called by /etc/hotplug.d/iface/16-mwan3-user for enabled mwan3
+# interfaces. The detached helper sends only a bounded "reconcile now"
+# request; vanpi queries mwan3 itself for authoritative current state.
+
+case "${ACTION:-}" in
+  ifup | ifdown | connected | disconnected)
+    /usr/libexec/vanpi-policy-trigger \
+      "${ACTION:-unknown}" "${INTERFACE:-unknown}" || true
+    ;;
+esac
+
+exit 0

--- a/vanrouter/usr/libexec/vanpi-policy-trigger
+++ b/vanrouter/usr/libexec/vanpi-policy-trigger
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+KEY_FILE=/etc/dropbear/vanpi-policy-trigger
+PID_FILE=/var/run/vanpi-policy-trigger.pid
+PI_TARGET=router-trigger@192.168.6.103
+TAG=vanpi-policy-trigger
+
+log_notice() {
+  /usr/bin/logger -p daemon.notice -t "$TAG" "$*"
+}
+
+log_error() {
+  /usr/bin/logger -p daemon.err -t "$TAG" "$*"
+}
+
+run_worker() {
+  action="${1:-unknown}"
+  interface="${2:-unknown}"
+  trap '/bin/rm -f -- "$PID_FILE"' 0 1 2 15
+
+  # mwan3 can emit several events while routes converge. Wait briefly, then
+  # request one idempotent reconciliation of the final state.
+  /bin/sleep 3
+  if [ ! -r "$KEY_FILE" ]; then
+    log_error "trigger key is unavailable after $action on $interface"
+    return 1
+  fi
+
+  /usr/bin/timeout --kill-after=2s 10s \
+    /usr/bin/dbclient \
+      -T \
+      -q \
+      -K 3 \
+      -I 8 \
+      -i "$KEY_FILE" \
+      "$PI_TARGET" \
+      reconcile \
+      </dev/null >/dev/null 2>&1
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    log_notice "requested vanpi reconciliation after $action on $interface"
+  else
+    log_error "vanpi reconciliation request failed after $action on $interface (status $status)"
+  fi
+  return "$status"
+}
+
+if [ "${1:-}" = "--worker" ]; then
+  shift
+  run_worker "$@"
+  exit $?
+fi
+
+action="${1:-unknown}"
+interface="${2:-unknown}"
+
+# Detach from mwan3's hotplug process. A live PID file coalesces event bursts;
+# the Pi's periodic reconciliation remains the fallback for a lost request.
+if ! /sbin/start-stop-daemon \
+    -S \
+    -b \
+    -m \
+    -p "$PID_FILE" \
+    -x "$0" \
+    -- --worker "$action" "$interface"; then
+  # Another worker is already waiting for mwan3 to settle.
+  exit 0
+fi


### PR DESCRIPTION
## Summary

- add a `vanpi-policy.service` oneshot for event-triggered lifecycle reconciliation
- dispatch that service from OpenWrt `/etc/mwan3.user` through a detached, bounded Dropbear worker
- constrain the router credential to one source IP, one dedicated locked account, and one forced `systemctl start` command
- pin the Pi host key on OpenWrt; the private trigger key remains only on the router
- query `mwan3 interfaces` once per policy run and fail closed when SSH or report validation fails
- retain the minutely cron invocation as reconciliation and stall-canary fallback

## Why

Pi-side NetworkManager cannot observe WAN transitions behind the stable Pi-to-router LAN connection. OpenWrt is the authoritative event source, while the Pi remains the policy owner and independently verifies current mwan3 state before acting.

## Security

- the router cannot obtain a shell, forward connections, allocate a PTY, choose a command, or authenticate from another source address
- the dedicated Pi account has no supplementary groups and its password is locked
- sudo permits only `systemctl start --no-block vanpi-policy.service`
- the service executes the existing policy as `pi`

## Validation

- Bash/ash syntax checks, `systemd-analyze verify`, and `git diff --check` passed
- exact online/offline parsing matched live mwan3 state
- a failed/timeout router query returned nonzero without changing policy state
- an attempted router-side `id` command was replaced by the forced service trigger
- a synthetic mwan3 event and later natural transitions started the service successfully
- router and Pi repository/deployment checksums and the pinned host key matched
- lifecycle and backup locks were free afterward; `EXFAT512`, `movingparts`, and `mbp2tbkup` remained mounted
- the cron reconciliation fallback remains installed