### PR TITLE
Add van dashboard and COP alert guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,35 @@ Some ignored secret directories, wireless profiles, and device configurations
 may contain credentials or private network data. Never print or commit secrets,
 and preserve unrelated local or deployed changes.
 
+## Vanpi CAN/UDS workspace
+
+The primary CAN-bus research and diagnostic toolkit is a separate Git checkout
+on vanpi at `/home/pi/dev/obd-things/`; it is not mirrored by this repository.
+Before CAN/UDS work, inspect that live checkout and its Git status, then read its
+root `README.md`, `CLAUDE.md`, and `docs/bus-map.md`. It may contain active,
+uncommitted investigations, so preserve its changes independently from this
+repository.
+
+Its main contents are:
+
+- `bringup.sh`: PCAN/SocketCAN setup for C-CAN (500 kbit/s) and B-CAN
+  (125 kbit/s), passive/listen-only by default; transmit mode is explicit.
+- `lib/`: reusable CAN interface/bus detection and wake helpers, ISO-TP/UDS
+  request handling, and the ECU/module-address registry.
+- `tools/`: generic UDS requests and DID/routine discovery, CAN field finding,
+  signal correlation, decoding, and capture helpers.
+- `live_data/`: reusable terminal live-data viewer infrastructure.
+- `projects/`: battery-voltage, ECU-mapping, radar/ACC, and TPMS investigations,
+  with project-specific READMEs, scripts, findings, and some systemd units.
+- `tmp/`: ignored, transient captures, sweeps, logs, locks, and other runtime
+  output. Durable findings are deliberately promoted into the relevant
+  `projects/<name>/findings/` directory.
+
+Some helpers can reconfigure `can0`, wake a bus, issue diagnostic requests, or
+perform safety-critical radar actuation. Their presence is not authorization to
+run them: follow the live repo's guidance, coordinate with any service owning
+the interface, and retain the CAN-transmission safeguards below.
+
 ## Live infrastructure safety
 
 - Prefer read-only inspection before changing routing, wireless, firewall,

--- a/automation/van_dashboard.py
+++ b/automation/van_dashboard.py
@@ -1,0 +1,875 @@
+#!/usr/bin/env python3
+"""Phone-friendly control surface for vanpi.
+
+The first dashboard feature is COP ALERT.  While active it:
+
+* keeps Home Assistant's ``switch.ext_flood`` on while the engine is stopped;
+* periodically wakes C-CAN with a benign RF Hub identification read so the
+  dash accessory rail (and therefore the dashcam) stays awake;
+* emits a bacon ntfy notification every five minutes; and
+* publishes fresh, passive C-CAN engine-running evidence for ignition_on.sh.
+
+The CAN receive path is passive.  The only transmitted frame is the explicitly
+requested RF Hub ReadDataByIdentifier wake.  This process deliberately does not
+bring can0 up/down or change its bitrate/listen-only state because the interface
+is shared with other vehicle tooling.
+"""
+
+import json
+import os
+import re
+import socket
+import struct
+import subprocess
+import threading
+import time
+from urllib.parse import urlsplit
+
+from flask import Flask, jsonify, request
+
+
+PORT = int(os.environ.get("VAN_DASHBOARD_PORT", "8788"))
+STATE_PATH = os.path.expanduser(
+    os.environ.get("VAN_DASHBOARD_STATE_PATH", "~/.van_dashboard_state.json")
+)
+RUNTIME_DIR = os.environ.get("VAN_DASHBOARD_RUNTIME_DIR", "/run/van-dashboard")
+ACTIVE_MARKER = os.path.join(RUNTIME_DIR, "cop-alert.active")
+ENGINE_MARKER = os.path.join(RUNTIME_DIR, "engine-running")
+
+TUYA_TOGGLE = os.environ.get("VAN_DASHBOARD_TUYA_TOGGLE", "/home/pi/scripts/tuya_toggle.sh")
+TUYA_STATUS = os.environ.get("VAN_DASHBOARD_TUYA_STATUS", "/home/pi/scripts/tuya_status.sh")
+NTFY_SEND = os.environ.get("VAN_DASHBOARD_NTFY_SEND", "/home/pi/scripts/ntfy_send.sh")
+
+CAN_CHANNEL = os.environ.get("VAN_DASHBOARD_CAN_CHANNEL", "can0")
+CAN_BITRATE = 500000
+# Two independent C-CAN engine-speed broadcasts. 0x0FC varies naturally around
+# idle while 0x0F4 held the same steady 752 RPM value in the reference capture;
+# requiring both avoids treating either field alone as proof.
+ENGINE_FRAME_DIVISORS = {0x0F4: 8.0, 0x0FC: 4.0}
+ENGINE_ACTUAL_FRAME_ID = 0x0FC
+ENGINE_RUNNING_MIN_RPM = 300.0
+ENGINE_RUNNING_MAX_RPM = 8000.0
+ENGINE_CONFIRM_FRAMES = 5
+ENGINE_EVIDENCE_MAX_AGE = 2.5
+CAN_EFF_FLAG = 0x80000000
+CAN_RTR_FLAG = 0x40000000
+CAN_SFF_MASK = 0x7FF
+
+# An RF Hub identification read is a verified, non-actuating C-CAN wake.  Its
+# network-management wake powers the dash accessory rail for roughly 30-60 s.
+RFH_TXID = 0x18DAC7F1
+RFH_RXID = 0x18DAF1C7
+RFH_WAKE_REQUEST = bytes((0x22, 0xF1, 0x90))
+WAKE_INTERVAL = float(os.environ.get("VAN_DASHBOARD_WAKE_INTERVAL", "15"))
+NTFY_INTERVAL = float(os.environ.get("VAN_DASHBOARD_NTFY_INTERVAL", "300"))
+FLOOD_CHECK_INTERVAL = float(os.environ.get("VAN_DASHBOARD_FLOOD_CHECK_INTERVAL", "15"))
+
+DEFAULT_SONOS_DEVICE = os.environ.get("VAN_DASHBOARD_SONOS_DEVICE", "vonFront")
+
+
+def atomic_json_write(path, value):
+    """Write JSON without leaving a partially-written state file."""
+    parent = os.path.dirname(path) or "."
+    os.makedirs(parent, exist_ok=True)
+    tmp = f"{path}.tmp.{os.getpid()}"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        json.dump(value, handle, indent=1, sort_keys=True)
+        handle.write("\n")
+    os.replace(tmp, path)
+
+
+class StateStore:
+    def __init__(self, path=STATE_PATH):
+        self.path = path
+        self.lock = threading.RLock()
+        try:
+            with open(path, encoding="utf-8") as handle:
+                loaded = json.load(handle)
+            self.data = loaded if isinstance(loaded, dict) else {}
+        except (OSError, ValueError):
+            self.data = {}
+        self.data.setdefault("cop_alert", False)
+        self.data.setdefault("sonos_device", None)
+
+    def get(self, key, default=None):
+        with self.lock:
+            return self.data.get(key, default)
+
+    def set(self, key, value):
+        with self.lock:
+            self.data[key] = value
+            atomic_json_write(self.path, self.data)
+
+
+def rpm_from_engine_frame(can_id, data):
+    """Decode the verified C-CAN engine-speed broadcast, or return None.
+
+    2026-07 labeled captures on this van showed both fields at 0 with ignition
+    on/engine stopped. At idle, 0x0F4 was 0x1780 (6016 / 8 = 752 RPM) while
+    0x0FC varied around 0x0BC0 (3008 / 4 = 752 RPM).
+    """
+    divisor = ENGINE_FRAME_DIVISORS.get(can_id)
+    if divisor is None or len(data) < 2:
+        return None
+    return ((data[0] << 8) | data[1]) / divisor
+
+
+class EngineMonitor:
+    """Passively track fresh engine-running evidence from C-CAN."""
+
+    def __init__(self, channel=CAN_CHANNEL, clock=time.monotonic):
+        self.channel = channel
+        self.clock = clock
+        self.lock = threading.Lock()
+        self.stop_event = threading.Event()
+        self.thread = None
+        self.last_frame_at = None
+        self.last_running_at = {can_id: None for can_id in ENGINE_FRAME_DIVISORS}
+        self.last_rpm = {can_id: None for can_id in ENGINE_FRAME_DIVISORS}
+        self.confirmations = {can_id: 0 for can_id in ENGINE_FRAME_DIVISORS}
+        self.error = "waiting for C-CAN engine-speed frames"
+
+    def start(self):
+        if not self.thread:
+            self.thread = threading.Thread(target=self._loop, name="engine-monitor", daemon=True)
+            self.thread.start()
+
+    def stop(self):
+        self.stop_event.set()
+
+    def observe(self, can_id, data, observed_at=None):
+        """Record one frame. Public so the decoder can be tested offline."""
+        rpm = rpm_from_engine_frame(can_id, data)
+        if rpm is None:
+            return
+        now = self.clock() if observed_at is None else observed_at
+        with self.lock:
+            self.last_frame_at = now
+            self.last_rpm[can_id] = rpm
+            self.error = None
+            if ENGINE_RUNNING_MIN_RPM <= rpm <= ENGINE_RUNNING_MAX_RPM:
+                self.confirmations[can_id] = min(
+                    ENGINE_CONFIRM_FRAMES, self.confirmations[can_id] + 1
+                )
+                if self.confirmations[can_id] >= ENGINE_CONFIRM_FRAMES:
+                    self.last_running_at[can_id] = now
+            else:
+                self.confirmations[can_id] = 0
+                self.last_running_at[can_id] = None
+
+    def snapshot(self):
+        now = self.clock()
+        with self.lock:
+            running_ages = [
+                now - self.last_running_at[can_id]
+                for can_id in ENGINE_FRAME_DIVISORS
+                if self.last_running_at[can_id] is not None
+            ]
+            running_age = max(running_ages) if len(running_ages) == len(ENGINE_FRAME_DIVISORS) else None
+            frame_age = None if self.last_frame_at is None else now - self.last_frame_at
+            running = running_age is not None and running_age <= ENGINE_EVIDENCE_MAX_AGE
+            rpm = self.last_rpm[ENGINE_ACTUAL_FRAME_ID]
+            if rpm is None:
+                rpm = next((value for value in self.last_rpm.values() if value is not None), None)
+            return {
+                "running": running,
+                "rpm": round(rpm, 1) if rpm is not None else None,
+                "evidence_age_seconds": round(running_age, 2) if running_age is not None else None,
+                "frame_age_seconds": round(frame_age, 2) if frame_age is not None else None,
+                "source": "C-CAN 0x0F4 BE/8 + 0x0FC BE/4",
+                "error": self.error,
+            }
+
+    def _loop(self):
+        while not self.stop_event.is_set():
+            can_socket = None
+            try:
+                can_socket = socket.socket(socket.AF_CAN, socket.SOCK_RAW, socket.CAN_RAW)
+                can_socket.setsockopt(
+                    socket.SOL_CAN_RAW,
+                    socket.CAN_RAW_FILTER,
+                    # Match only standard, non-RTR engine-speed data frames.
+                    # Without the flag bits in the mask, unrelated extended
+                    # frames with matching low 11 bits could be misclassified.
+                    b"".join(
+                        struct.pack(
+                            "=II",
+                            can_id,
+                            CAN_EFF_FLAG | CAN_RTR_FLAG | CAN_SFF_MASK,
+                        )
+                        for can_id in ENGINE_FRAME_DIVISORS
+                    ),
+                )
+                can_socket.bind((self.channel,))
+                can_socket.settimeout(1.0)
+                with self.lock:
+                    self.error = None
+                while not self.stop_event.is_set():
+                    try:
+                        frame = can_socket.recv(16)
+                    except socket.timeout:
+                        continue
+                    can_id, dlc, payload = struct.unpack("=IB3x8s", frame)
+                    if can_id & (CAN_EFF_FLAG | CAN_RTR_FLAG):
+                        continue
+                    self.observe(can_id & CAN_SFF_MASK, payload[:dlc])
+            except OSError as exc:
+                with self.lock:
+                    self.error = f"{self.channel} receive unavailable: {exc}"
+                self.stop_event.wait(2.0)
+            finally:
+                if can_socket is not None:
+                    can_socket.close()
+
+
+def run_command(args, timeout=20):
+    return subprocess.run(args, capture_output=True, text=True, timeout=timeout, check=False)
+
+
+def c_can_link_status(command=run_command):
+    """Confirm the shared interface is already safe for the requested C-CAN TX."""
+    try:
+        result = command(["/usr/sbin/ip", "-details", "link", "show", CAN_CHANNEL], timeout=5)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"cannot inspect {CAN_CHANNEL}: {exc}"
+    output = f"{result.stdout}\n{result.stderr}"
+    if result.returncode:
+        return False, f"{CAN_CHANNEL} is unavailable"
+    if not re.search(r"\bstate UP\b|<[^>]*\bUP\b[^>]*>", output):
+        return False, f"{CAN_CHANNEL} is down"
+    match = re.search(r"\bbitrate\s+(\d+)", output)
+    bitrate = int(match.group(1)) if match else None
+    if bitrate != CAN_BITRATE:
+        return False, f"{CAN_CHANNEL} is not C-CAN speed (found {bitrate or 'unknown'} bit/s)"
+    if "LISTEN-ONLY" in output:
+        return False, f"{CAN_CHANNEL} is listen-only; shared interface was not reconfigured"
+    return True, f"{CAN_CHANNEL} armed at {CAN_BITRATE} bit/s"
+
+
+def send_c_can_wake(command=run_command):
+    """Send one self-validating RF Hub identification read.
+
+    A response (positive or negative) proves that the addressed exchange occurred.
+    No interface settings are changed here.
+    """
+    ready, detail = c_can_link_status(command)
+    if not ready:
+        return False, detail
+    wake_socket = None
+    try:
+        import isotp  # lazy: the dashboard and Sonos UI can still start if CAN tooling is absent
+
+        wake_socket = isotp.socket()
+        wake_socket.set_fc_opts(stmin=0, bs=0)
+        wake_socket.bind(
+            CAN_CHANNEL,
+            address=isotp.Address(
+                isotp.AddressingMode.Normal_29bits,
+                txid=RFH_TXID,
+                rxid=RFH_RXID,
+            ),
+        )
+        wake_socket.settimeout(1.5)
+        wake_socket.send(RFH_WAKE_REQUEST)
+        response = wake_socket.recv()
+    except (ImportError, OSError, RuntimeError) as exc:
+        return False, f"C-CAN wake failed: {exc}"
+    except Exception as exc:  # can-isotp uses its own timeout/error classes across versions
+        return False, f"C-CAN wake got no RF Hub response: {exc}"
+    finally:
+        if wake_socket is not None:
+            try:
+                wake_socket.close()
+            except Exception:
+                pass
+    if not response:
+        return False, "C-CAN wake got no RF Hub response"
+    return True, "RF Hub answered; C-CAN/dashcam wake refreshed"
+
+
+class CopAlertManager:
+    def __init__(
+        self,
+        store,
+        engine_monitor,
+        command=run_command,
+        wake=send_c_can_wake,
+        runtime_dir=RUNTIME_DIR,
+        clock=time.monotonic,
+        wall_clock=time.time,
+    ):
+        self.store = store
+        self.engine_monitor = engine_monitor
+        self.command = command
+        self.wake = wake
+        self.runtime_dir = runtime_dir
+        self.active_marker = os.path.join(runtime_dir, os.path.basename(ACTIVE_MARKER))
+        self.engine_marker = os.path.join(runtime_dir, os.path.basename(ENGINE_MARKER))
+        self.clock = clock
+        self.wall_clock = wall_clock
+        self.lock = threading.RLock()
+        self.stop_event = threading.Event()
+        self.thread = None
+        self.ext_flood = "unknown"
+        self.errors = {}
+        self.last_wake = None
+        self.last_wake_ok = None
+        self.last_wake_message = "not attempted"
+        self.last_ntfy = None
+        self.next_wake = 0.0
+        self.next_flood_check = 0.0
+        self.next_ntfy = 0.0
+
+    def start(self):
+        os.makedirs(self.runtime_dir, mode=0o750, exist_ok=True)
+        self.engine_monitor.start()
+        if not self.thread:
+            self.thread = threading.Thread(target=self._loop, name="cop-alert", daemon=True)
+            self.thread.start()
+
+    def stop(self):
+        self.stop_event.set()
+        self.engine_monitor.stop()
+
+    @property
+    def active(self):
+        return bool(self.store.get("cop_alert", False))
+
+    def set_active(self, active):
+        active = bool(active)
+        self.store.set("cop_alert", active)
+        with self.lock:
+            self.errors.clear()
+            if active:
+                self._touch(self.active_marker)
+                self.next_wake = 0.0
+                self.next_flood_check = 0.0
+                self.next_ntfy = 0.0
+            else:
+                self._remove(self.active_marker)
+                self._remove(self.engine_marker)
+
+        # Give the button immediate, deterministic switch behavior.  Background
+        # retries and status reporting handle a temporarily unavailable HA API.
+        desired = "on" if active else "off"
+        ok, message = self._set_ext_flood(desired)
+        if not ok:
+            self._set_error("ext_flood", message)
+        return self.snapshot()
+
+    def snapshot(self):
+        engine = self.engine_monitor.snapshot()
+        with self.lock:
+            last_error = "; ".join(self.errors.values()) or None
+            return {
+                "active": self.active,
+                "engine": engine,
+                "ext_flood": self.ext_flood,
+                "last_wake": self.last_wake,
+                "last_wake_ok": self.last_wake_ok,
+                "last_wake_message": self.last_wake_message,
+                "last_ntfy": self.last_ntfy,
+                "last_error": last_error,
+                "wake_mode": (
+                    f"C-CAN RF Hub 22 F190 every {WAKE_INTERVAL:g} seconds while engine-stopped"
+                ),
+            }
+
+    def tick(self):
+        """Run one manager iteration; separated for focused tests."""
+        now = self.clock()
+        if not self.active:
+            self._remove(self.active_marker)
+            self._remove(self.engine_marker)
+            if now >= self.next_flood_check:
+                self.next_flood_check = now + FLOOD_CHECK_INTERVAL
+                self._get_ext_flood()
+            return
+
+        self._touch(self.active_marker)
+        engine = self.engine_monitor.snapshot()
+        if engine["running"]:
+            self._touch(self.engine_marker)
+        else:
+            self._remove(self.engine_marker)
+
+        if now >= self.next_flood_check:
+            self.next_flood_check = now + FLOOD_CHECK_INTERVAL
+            desired = "off" if engine["running"] else "on"
+            actual = self._get_ext_flood()
+            if actual != desired:
+                ok, message = self._set_ext_flood(desired)
+                if not ok:
+                    self._set_error("ext_flood", message)
+
+        # A running engine is already broadcasting and powers the dashcam. Do
+        # not add diagnostic traffic; resume parked wakes if the engine stops.
+        if not engine["running"] and now >= self.next_wake:
+            ok, message = self.wake()
+            with self.lock:
+                self.last_wake = int(self.wall_clock())
+                self.last_wake_ok = bool(ok)
+                self.last_wake_message = message
+            self._set_error("can_wake", None if ok else message)
+            self.next_wake = now + (WAKE_INTERVAL if ok else min(5.0, WAKE_INTERVAL))
+
+        if now >= self.next_ntfy:
+            ok, message = self._send_ntfy()
+            if ok:
+                with self.lock:
+                    self.last_ntfy = int(self.wall_clock())
+                self._set_error("ntfy", None)
+                self.next_ntfy = now + NTFY_INTERVAL
+            else:
+                self._set_error("ntfy", message)
+                self.next_ntfy = now + min(30.0, NTFY_INTERVAL)
+
+        self._set_error("manager", None)
+
+    def _loop(self):
+        while not self.stop_event.is_set():
+            try:
+                self.tick()
+            except Exception as exc:
+                self._set_error("manager", f"COP ALERT loop error: {exc}")
+            self.stop_event.wait(1.0)
+
+    def _set_ext_flood(self, desired):
+        try:
+            result = self.command([TUYA_TOGGLE, "ext_flood", desired], timeout=20)
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return False, f"ext_flood {desired} failed: {exc}"
+        if result.returncode:
+            detail = (result.stderr or result.stdout or "command failed").strip()
+            return False, f"ext_flood {desired} failed: {detail}"
+        with self.lock:
+            self.ext_flood = desired
+        self._set_error("ext_flood", None)
+        return True, f"ext_flood is {desired}"
+
+    def _get_ext_flood(self):
+        try:
+            result = self.command([TUYA_STATUS, "ext_flood"], timeout=20)
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            self._set_error("ext_flood", f"ext_flood status failed: {exc}")
+            return "unknown"
+        state = result.stdout.strip().lower()
+        if result.returncode == 0 and state in ("on", "off"):
+            with self.lock:
+                self.ext_flood = state
+            self._set_error("ext_flood", None)
+            return state
+        with self.lock:
+            self.ext_flood = "unknown"
+        self._set_error("ext_flood", "could not read ext_flood state")
+        return "unknown"
+
+    def _send_ntfy(self):
+        try:
+            result = self.command(
+                [NTFY_SEND, "COP ALERT", "🥓 COP ALERT is active", "high", "bacon"],
+                timeout=20,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return False, f"COP ALERT ntfy failed: {exc}"
+        if result.returncode:
+            detail = (result.stderr or result.stdout or "command failed").strip()
+            return False, f"COP ALERT ntfy failed: {detail}"
+        return True, "COP ALERT ntfy sent"
+
+    def _set_error(self, component, message):
+        with self.lock:
+            if message:
+                self.errors[component] = message
+            else:
+                self.errors.pop(component, None)
+
+    @staticmethod
+    def _touch(path):
+        os.makedirs(os.path.dirname(path), mode=0o750, exist_ok=True)
+        with open(path, "a", encoding="utf-8"):
+            os.utime(path, None)
+
+    @staticmethod
+    def _remove(path):
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+
+
+class SonosController:
+    """Small Sonos grouping/volume controller matching the audiobook page."""
+
+    def __init__(self, store, discover_func=None, clock=time.monotonic):
+        self.store = store
+        self.discover_func = discover_func
+        self.clock = clock
+        self.lock = threading.Lock()
+        self.zones = {}
+        self.zones_at = 0.0
+
+    def get_zones(self, force=False):
+        with self.lock:
+            if self.zones and not force and self.clock() - self.zones_at < 600:
+                return self.zones
+            if self.discover_func is None:
+                from soco.discovery import discover
+
+                found = discover(timeout=5) or set()
+            else:
+                found = self.discover_func(timeout=5) or set()
+            fresh = {zone.player_name: zone for zone in found if zone.is_visible}
+            if fresh:
+                self.zones = fresh
+                self.zones_at = self.clock()
+            return self.zones
+
+    def coordinator(self):
+        zones = self.get_zones()
+        if not zones:
+            zones = self.get_zones(force=True)
+        if not zones:
+            raise RuntimeError("no Sonos speakers found")
+        remembered = self.store.get("sonos_device")
+        if remembered in zones:
+            return zones[remembered].group.coordinator
+        for zone in zones.values():
+            if zone.group.coordinator != zone:
+                continue
+            try:
+                state = zone.get_current_transport_info()["current_transport_state"]
+            except Exception:
+                continue
+            if state == "PLAYING":
+                return zone
+        if DEFAULT_SONOS_DEVICE in zones:
+            return zones[DEFAULT_SONOS_DEVICE].group.coordinator
+        return next(iter(zones.values())).group.coordinator
+
+    def snapshot(self):
+        zones = self.get_zones()
+        if not zones:
+            raise RuntimeError("no Sonos speakers found")
+        coordinator = self.coordinator()
+        coordinator_name = coordinator.player_name
+        members = {member.player_name for member in coordinator.group.members}
+        speakers = []
+        for name, zone in sorted(zones.items()):
+            try:
+                volume = zone.volume
+            except Exception:
+                volume = None
+            speakers.append(
+                {
+                    "name": name,
+                    "volume": volume,
+                    "grouped": name in members,
+                    "coordinator": name == coordinator_name,
+                    "group_coordinator": zone.group.coordinator.player_name,
+                }
+            )
+        return {"ok": True, "coordinator": coordinator_name, "speakers": speakers}
+
+    def select(self, name):
+        zones = self.get_zones()
+        if name not in zones:
+            raise KeyError(f"unknown speaker '{name}'")
+        coordinator = zones[name].group.coordinator
+        self.store.set("sonos_device", coordinator.player_name)
+        return coordinator.player_name
+
+    def group(self, name, grouped):
+        zones = self.get_zones()
+        if name not in zones:
+            raise KeyError(f"unknown speaker '{name}'")
+        coordinator = self.coordinator()
+        speaker = zones[name]
+        if not grouped and speaker.player_name == coordinator.player_name:
+            raise ValueError("select another group before removing its coordinator")
+        members = {member.player_name for member in coordinator.group.members}
+        if grouped and name not in members:
+            speaker.join(coordinator)
+            message = f"added {name} to {coordinator.player_name}"
+        elif not grouped and name in members:
+            speaker.unjoin()
+            message = f"removed {name} from {coordinator.player_name}"
+        else:
+            message = f"{name} group is unchanged"
+        self.get_zones(force=True)
+        return message
+
+    def set_volume(self, name, volume):
+        zones = self.get_zones()
+        if name not in zones:
+            raise KeyError(f"unknown speaker '{name}'")
+        volume = max(0, min(100, int(volume)))
+        zones[name].volume = volume
+        return volume
+
+
+app = Flask(__name__)
+state_store = StateStore()
+engine_monitor = EngineMonitor()
+cop_alert = CopAlertManager(state_store, engine_monitor)
+sonos = SonosController(state_store)
+
+
+def api_error(message, status):
+    return jsonify({"ok": False, "message": str(message)}), status
+
+
+@app.before_request
+def reject_cross_origin_mutations():
+    """Block browser CSRF against vehicle-control POST endpoints.
+
+    Command-line clients without browser Origin/Referer headers remain usable.
+    The custom header also forces a cross-origin fetch to preflight, and this
+    server intentionally grants no cross-origin access.
+    """
+    if request.method != "POST":
+        return None
+    origin = request.headers.get("Origin")
+    referer = request.headers.get("Referer")
+    if origin:
+        if urlsplit(origin).netloc != request.host:
+            return api_error("cross-origin control request rejected", 403)
+        if request.headers.get("X-Van-Dashboard") != "1":
+            return api_error("dashboard control header missing", 403)
+    elif referer and urlsplit(referer).netloc != request.host:
+        return api_error("cross-origin control request rejected", 403)
+    return None
+
+
+@app.route("/api/status")
+def api_status():
+    return jsonify({"ok": True, "cop_alert": cop_alert.snapshot()})
+
+
+@app.route("/api/cop-alert", methods=["POST"])
+def api_cop_alert():
+    raw = request.values.get("active", "").strip().lower()
+    if raw not in ("1", "0", "true", "false", "on", "off"):
+        return api_error("active must be true or false", 400)
+    active = raw in ("1", "true", "on")
+    status = cop_alert.set_active(active)
+    verb = "armed" if active else "disarmed"
+    return jsonify({"ok": True, "message": f"COP ALERT {verb}", "cop_alert": status})
+
+
+@app.route("/api/speakers")
+def api_speakers():
+    try:
+        return jsonify(sonos.snapshot())
+    except Exception as exc:
+        return api_error(f"speaker discovery failed: {exc}", 503)
+
+
+@app.route("/api/speakers/select", methods=["POST"])
+def api_speaker_select():
+    name = request.values.get("name", "").strip()
+    if not name:
+        return api_error("need name", 400)
+    try:
+        selected = sonos.select(name)
+    except KeyError as exc:
+        return api_error(exc.args[0], 404)
+    except Exception as exc:
+        return api_error(f"could not select Sonos group: {exc}", 502)
+    return jsonify({"ok": True, "message": f"using {selected}", "device": selected})
+
+
+@app.route("/api/speakers/group", methods=["POST"])
+def api_speaker_group():
+    name = request.values.get("name", "").strip()
+    grouped = request.values.get("grouped", "").lower() in ("1", "true", "yes")
+    try:
+        message = sonos.group(name, grouped)
+    except KeyError as exc:
+        return api_error(exc.args[0], 404)
+    except ValueError as exc:
+        return api_error(exc, 400)
+    except Exception as exc:
+        return api_error(f"could not update Sonos group: {exc}", 502)
+    return jsonify({"ok": True, "message": message})
+
+
+@app.route("/api/speakers/volume", methods=["POST"])
+def api_speaker_volume():
+    name = request.values.get("name", "").strip()
+    try:
+        volume = int(request.values.get("volume", ""))
+    except (TypeError, ValueError):
+        return api_error("volume must be from 0 to 100", 400)
+    try:
+        volume = sonos.set_volume(name, volume)
+    except KeyError as exc:
+        return api_error(exc.args[0], 404)
+    except Exception as exc:
+        return api_error(f"could not set {name} volume: {exc}", 502)
+    return jsonify({"ok": True, "message": f"{name} volume: {volume}", "volume": volume})
+
+
+PAGE = r"""<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="apple-mobile-web-app-title" content="Van Dashboard">
+<meta name="theme-color" content="#111820">
+<link rel="manifest" href="/manifest.webmanifest">
+<link rel="icon" href="/app-icon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="/app-icon.svg">
+<title>Van Dashboard</title>
+<style>
+:root{color-scheme:dark;--bg:#111820;--panel:#19232d;--raised:#22313d;--ink:#eef5f8;
+  --dim:#96a8b3;--accent:#51b7c6;--line:#2b3d49;--good:#62c899;--bad:#ef7067;
+  --alert:#ef503f;--alert2:#ff9b43;--shadow:0 14px 45px #050a0e88}
+*{box-sizing:border-box}html{background:var(--bg)}
+body{margin:0;min-height:100vh;padding:env(safe-area-inset-top) 14px calc(28px + env(safe-area-inset-bottom));
+  background:radial-gradient(circle at 86% -4%,#275a6b66,transparent 34%),var(--bg);color:var(--ink);
+  font:16px/1.4 -apple-system,BlinkMacSystemFont,"SF Pro Text",system-ui,sans-serif}
+main,header{width:min(100%,680px);margin:auto}button,input{font:inherit}button{color:inherit;-webkit-tap-highlight-color:transparent}
+header{display:flex;align-items:center;justify-content:space-between;padding:24px 2px 18px}
+.eyebrow{color:var(--accent);font-size:11px;font-weight:750;letter-spacing:.16em;text-transform:uppercase}
+h1{font-size:29px;line-height:1.05;letter-spacing:-.03em;margin:3px 0 0}.van-mark{font-size:28px;filter:grayscale(.2)}
+.connection{display:flex;align-items:center;gap:7px;color:var(--dim);font-size:12px;margin:0 2px 14px}
+.dot{width:8px;height:8px;border-radius:50%;background:var(--bad);box-shadow:0 0 0 3px #ef706718}
+.dot.on{background:var(--good);box-shadow:0 0 0 3px #62c89920}
+.grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:11px}
+.tile{min-height:150px;border:1px solid var(--line);border-radius:19px;background:linear-gradient(145deg,var(--panel),#151f28);
+  padding:15px;text-decoration:none;color:inherit;box-shadow:0 8px 28px #050b102e;display:flex;flex-direction:column;
+  align-items:flex-start;text-align:left;cursor:pointer;position:relative;overflow:hidden}
+.tile:active{background:var(--raised);transform:scale(.985)}.tile-icon{font-size:31px;line-height:1;margin-bottom:auto}
+.tile-title{font-size:17px;font-weight:760;letter-spacing:-.01em}.tile-detail{font-size:12px;color:var(--dim);margin-top:3px;min-height:34px}
+.cop{grid-column:1/-1;min-height:210px;border-color:#744238;background:radial-gradient(circle at 92% 5%,#ef503f33,transparent 35%),linear-gradient(145deg,#292124,#1c2026)}
+.cop .tile-icon{font-size:38px}.cop .tile-title{font-size:23px}.cop::after{content:"";position:absolute;inset:auto -25% -80% 25%;height:180px;
+  background:var(--alert);filter:blur(60px);opacity:0;transition:opacity .25s}.cop.active{border-color:#ef675a;box-shadow:0 10px 40px #ef503f25}
+.cop.active::after{opacity:.35}.cop.active .tile-title{color:#ffd7d2}.pill{position:absolute;right:14px;top:14px;border:1px solid var(--line);
+  border-radius:99px;padding:4px 8px;font-size:10px;font-weight:800;letter-spacing:.1em;color:var(--dim);background:#10171dcc}
+.cop.active .pill{color:#fff1ef;background:#8b2d27;border-color:#bf473d}.status-lines{display:grid;gap:4px;margin-top:12px;width:100%;font-size:11px;color:var(--dim)}
+.status-line{display:flex;justify-content:space-between;gap:10px}.status-line span:last-child{text-align:right;color:#c5d1d7;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.speaker-backdrop{position:fixed;z-index:20;inset:0;background:#05090daa;display:flex;align-items:flex-end;opacity:0;pointer-events:none;transition:opacity .2s}
+.speaker-backdrop.open{opacity:1;pointer-events:auto}.speaker-sheet{width:min(100%,680px);max-height:min(78vh,680px);overflow:auto;margin:0 auto;
+  background:#141e26;border:1px solid #38505e;border-bottom:0;border-radius:22px 22px 0 0;padding:8px 14px calc(18px + env(safe-area-inset-bottom));
+  box-shadow:0 -18px 60px #000a;transform:translateY(24px);transition:transform .2s}.speaker-backdrop.open .speaker-sheet{transform:translateY(0)}
+.sheet-grabber{width:38px;height:4px;border-radius:3px;background:#4d626e;margin:2px auto 12px}.sheet-head{display:flex;align-items:center;justify-content:space-between;gap:12px}
+.sheet-head h2{margin:0;font-size:18px;letter-spacing:-.01em}.sheet-close{border:1px solid var(--line);background:var(--raised);color:var(--ink);border-radius:50%;width:38px;height:38px;font-size:20px}
+.sheet-help{color:var(--dim);font-size:12px;margin:3px 0 14px}.speaker-row{display:grid;grid-template-columns:30px minmax(0,1fr) 35px;align-items:center;column-gap:8px;padding:11px 8px;border-top:1px solid var(--line)}
+.speaker-check{width:22px;height:22px;margin:0;accent-color:var(--accent)}.speaker-name{border:0;background:transparent;color:var(--ink);padding:2px 0;text-align:left;font-weight:700;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.speaker-name small{display:block;color:var(--dim);font-size:10px;font-weight:500;margin-top:1px}.speaker-level{font-size:11px;color:var(--dim);text-align:right;font-variant-numeric:tabular-nums}
+.speaker-volume{grid-column:2/4;width:100%;margin:8px 0 0;accent-color:var(--accent)}.speaker-loading{padding:28px;text-align:center;color:var(--dim)}body.sheet-open{overflow:hidden}
+#toast{position:fixed;z-index:30;left:50%;top:calc(12px + env(safe-area-inset-top));transform:translate(-50%,-14px);width:min(calc(100% - 28px),620px);
+  background:#22313d;color:var(--ink);border:1px solid #405967;border-radius:13px;padding:11px 14px;box-shadow:var(--shadow);opacity:0;pointer-events:none;transition:.2s;font-size:13px;text-align:center}
+#toast.show{opacity:1;transform:translate(-50%,0)}#toast.bad{border-color:#874944;color:#ffd8d4}body.busy [data-action]{pointer-events:none;opacity:.55}
+@media(max-width:420px){.grid{gap:9px}.tile{min-height:140px}.cop{min-height:205px}}@media(prefers-reduced-motion:reduce){*{transition:none!important}}
+</style></head><body>
+<header><div><div class="eyebrow">vanpi controls</div><h1>Van Dashboard</h1></div><div class="van-mark" aria-hidden="true">🚐</div></header>
+<main>
+  <div class="connection"><span class="dot" id="dot"></span><span id="connection">Connecting to vanpi…</span></div>
+  <div class="grid">
+    <button class="tile cop" id="cop" data-action aria-pressed="false">
+      <span class="pill" id="cop-pill">OFF</span><span class="tile-icon" aria-hidden="true">🚨</span>
+      <span class="tile-title">COP ALERT</span><span class="tile-detail" id="cop-detail">Tap to keep the dashcam awake</span>
+      <span class="status-lines">
+        <span class="status-line"><span>Engine</span><span id="engine">Checking C-CAN…</span></span>
+        <span class="status-line"><span>ext_flood</span><span id="flood">—</span></span>
+        <span class="status-line"><span>CAN wake</span><span id="wake">—</span></span>
+      </span>
+    </button>
+    <a class="tile" id="books" data-action href="#"><span class="tile-icon" aria-hidden="true">📖</span><span class="tile-title">Audiobooks</span><span class="tile-detail">Open the Sonos audiobook library</span></a>
+    <button class="tile" id="speakers" data-action aria-haspopup="dialog" aria-expanded="false" aria-controls="speaker-panel">
+      <span class="tile-icon" aria-hidden="true">🔊</span><span class="tile-title">Sonos</span><span class="tile-detail" id="speaker-summary">Finding speakers…</span>
+    </button>
+  </div>
+</main>
+<div class="speaker-backdrop" id="speaker-backdrop">
+  <section class="speaker-sheet" id="speaker-panel" role="dialog" aria-modal="true" aria-labelledby="speaker-title">
+    <div class="sheet-grabber"></div><div class="sheet-head"><h2 id="speaker-title">Sonos speakers</h2><button class="sheet-close" id="speaker-close" aria-label="Close speaker selector">×</button></div>
+    <p class="sheet-help">Tap a name to control its group. Check speakers to group them with the active player.</p>
+    <div id="speaker-list"><div class="speaker-loading">Finding speakers…</div></div>
+  </section>
+</div>
+<div id="toast" role="status" aria-live="polite"></div>
+<script>
+const $=id=>document.getElementById(id);let dashboard=null,speakers=null,busy=false,toastTimer=0;
+function esc(v){return String(v??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
+function toast(message,bad=false){clearTimeout(toastTimer);const el=$('toast');el.textContent=message;el.className=bad?'show bad':'show';toastTimer=setTimeout(()=>el.className='',3400)}
+async function json(url,options){const response=await fetch(url,options);let data;try{data=await response.json()}catch(_){data={message:`Server returned ${response.status}`}}
+  if(!response.ok||data.ok===false)throw new Error(data.message||`Request failed (${response.status})`);return data}
+async function post(endpoint,params={}){return json('/api/'+endpoint,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded','X-Van-Dashboard':'1'},body:new URLSearchParams(params)})}
+async function action(work){if(busy)return;busy=true;document.body.classList.add('busy');try{const result=await work();if(result?.message)toast(result.message);await refresh()}
+  catch(error){toast(error.message,true)}finally{busy=false;document.body.classList.remove('busy')}}
+function age(ts){if(!ts)return 'never';const secs=Math.max(0,Date.now()/1000-ts);return secs<90?`${Math.round(secs)}s ago`:`${Math.round(secs/60)}m ago`}
+function updateStatus(data){dashboard=data.cop_alert;const active=dashboard.active,engine=dashboard.engine;$('dot').classList.add('on');$('connection').textContent='Connected · vanpi dashboard';
+  $('cop').classList.toggle('active',active);$('cop').setAttribute('aria-pressed',String(active));$('cop-pill').textContent=active?'ACTIVE':'OFF';
+  $('cop-detail').textContent=active?'Dashcam wake and 5-minute bacon alerts are active':'Tap to keep the dashcam awake';
+  $('engine').textContent=engine.running?`RUNNING · ${Math.round(engine.rpm)} RPM`:engine.rpm===null?'No fresh data':`Stopped · ${Math.round(engine.rpm)} RPM`;
+  $('flood').textContent=dashboard.ext_flood;$('wake').textContent=dashboard.last_wake_ok===null?'Not attempted':dashboard.last_wake_ok?`OK · ${age(dashboard.last_wake)}`:'DEGRADED';
+  if(active&&dashboard.last_error)$('connection').textContent=`Active with warning · ${dashboard.last_error}`}
+async function refresh(){try{updateStatus(await json('/api/status'))}catch(error){$('dot').classList.remove('on');$('connection').textContent=error.message}}
+function renderSpeakers(next){speakers=next;const grouped=next.speakers.filter(s=>s.grouped);$('speaker-summary').textContent=`${next.coordinator} · ${grouped.length}/${next.speakers.length} grouped`;
+  $('speaker-list').innerHTML=next.speakers.map(s=>{const detail=s.coordinator?'Active coordinator':s.grouped?`Grouped with ${next.coordinator}`:`Group: ${s.group_coordinator}`;
+    const volume=Number.isFinite(s.volume)?s.volume:0;return `<div class="speaker-row"><input class="speaker-check" data-action data-group-speaker="${esc(s.name)}" type="checkbox" ${s.grouped?'checked':''} ${s.coordinator?'disabled':''} aria-label="Group ${esc(s.name)}">
+      <button class="speaker-name" data-action data-select-speaker="${esc(s.name)}">${esc(s.name)}<small>${esc(detail)}</small></button><span class="speaker-level">${Number.isFinite(s.volume)?s.volume:'—'}</span>
+      <input class="speaker-volume" data-action data-speaker-volume="${esc(s.name)}" type="range" min="0" max="100" value="${volume}" ${Number.isFinite(s.volume)?'':'disabled'} aria-label="${esc(s.name)} volume"></div>`}).join('')||'<div class="speaker-loading">No Sonos speakers found</div>'}
+async function loadSpeakers(){const next=await json('/api/speakers');renderSpeakers(next);return next}
+async function openSpeakers(){$('speaker-backdrop').classList.add('open');document.body.classList.add('sheet-open');$('speakers').setAttribute('aria-expanded','true');
+  try{await loadSpeakers()}catch(error){$('speaker-list').innerHTML=`<div class="speaker-loading">${esc(error.message)}</div>`;toast(error.message,true)}}
+function closeSpeakers(){$('speaker-backdrop').classList.remove('open');document.body.classList.remove('sheet-open');$('speakers').setAttribute('aria-expanded','false');$('speakers').focus()}
+const bookUrl=new URL(window.location.href);bookUrl.port='8787';bookUrl.pathname='/';bookUrl.search='';bookUrl.hash='';$('books').href=bookUrl.toString();
+$('cop').addEventListener('click',()=>action(()=>post('cop-alert',{active:dashboard?.active?'false':'true'})));$('speakers').addEventListener('click',openSpeakers);$('speaker-close').addEventListener('click',closeSpeakers);
+$('speaker-backdrop').addEventListener('click',event=>{if(event.target===$('speaker-backdrop'))closeSpeakers()});document.addEventListener('keydown',event=>{if(event.key==='Escape')closeSpeakers()});
+document.addEventListener('input',event=>{const slider=event.target.closest('[data-speaker-volume]');if(slider)slider.closest('.speaker-row').querySelector('.speaker-level').textContent=slider.value});
+document.addEventListener('change',event=>{const checkbox=event.target.closest('[data-group-speaker]');if(checkbox)action(async()=>{try{return await post('speakers/group',{name:checkbox.dataset.groupSpeaker,grouped:checkbox.checked?'1':'0'})}finally{await loadSpeakers()}});
+  const slider=event.target.closest('[data-speaker-volume]');if(slider)action(async()=>{try{return await post('speakers/volume',{name:slider.dataset.speakerVolume,volume:slider.value})}finally{await loadSpeakers()}})});
+document.addEventListener('click',event=>{const selected=event.target.closest('[data-select-speaker]');if(selected)action(async()=>{const result=await post('speakers/select',{name:selected.dataset.selectSpeaker});await loadSpeakers();return result})});
+Promise.allSettled([refresh(),loadSpeakers()]).then(results=>{if(results[1].status==='rejected')$('speaker-summary').textContent='Sonos unavailable'});setInterval(()=>{if(!document.hidden)refresh()},5000);document.addEventListener('visibilitychange',()=>{if(!document.hidden)refresh()});
+</script></body></html>"""
+
+
+APP_ICON = """<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+<rect width="512" height="512" rx="112" fill="#19232d"/>
+<path d="M106 178h300l35 74v142c0 17-13 30-30 30H101c-17 0-30-13-30-30V252l35-74Z" fill="#51b7c6"/>
+<path d="M136 116h240l30 136H106l30-136Z" fill="#dbe9ee"/>
+<path d="M165 141h182l17 86H148l17-86Z" fill="#22313d"/>
+<circle cx="145" cy="385" r="42" fill="#111820"/><circle cx="367" cy="385" r="42" fill="#111820"/>
+<path d="M216 303h80" stroke="#ef503f" stroke-width="30" stroke-linecap="round"/>
+</svg>"""
+
+
+@app.route("/manifest.webmanifest")
+def manifest():
+    response = jsonify(
+        {
+            "name": "Van Dashboard",
+            "short_name": "Van",
+            "id": "/",
+            "start_url": "/",
+            "scope": "/",
+            "display": "standalone",
+            "background_color": "#111820",
+            "theme_color": "#111820",
+            "icons": [{"src": "/app-icon.svg", "sizes": "any", "type": "image/svg+xml"}],
+        }
+    )
+    response.mimetype = "application/manifest+json"
+    return response
+
+
+@app.route("/app-icon.svg")
+def app_icon():
+    response = app.response_class(APP_ICON, mimetype="image/svg+xml")
+    response.headers["Cache-Control"] = "public, max-age=86400"
+    return response
+
+
+@app.route("/")
+def index():
+    return PAGE
+
+
+if __name__ == "__main__":
+    cop_alert.start()
+    app.run(host="0.0.0.0", port=PORT, threaded=True)

--- a/automation/van_dashboard.py
+++ b/automation/van_dashboard.py
@@ -48,6 +48,7 @@ SPEEDTEST = os.path.expanduser(
 )
 CONNECTIVITY_INTERVAL = float(os.environ.get("VAN_DASHBOARD_CONNECTIVITY_INTERVAL", "30"))
 SPEEDTEST_TIMEOUT = float(os.environ.get("VAN_DASHBOARD_SPEEDTEST_TIMEOUT", "180"))
+TUYA_POLL_INTERVAL = float(os.environ.get("VAN_DASHBOARD_TUYA_POLL_INTERVAL", "15"))
 
 CAN_CHANNEL = os.environ.get("VAN_DASHBOARD_CAN_CHANNEL", "can0")
 CAN_BITRATE = 500000
@@ -507,6 +508,121 @@ class CopAlertManager:
             pass
 
 
+class TuyaSwitchManager:
+    """Cache and safely toggle one Home Assistant/Tuya switch."""
+
+    def __init__(
+        self,
+        entity,
+        command=run_command,
+        interval=TUYA_POLL_INTERVAL,
+        wall_clock=time.time,
+    ):
+        self.entity = entity
+        self.command = command
+        self.interval = interval
+        self.wall_clock = wall_clock
+        self.lock = threading.Lock()
+        self.operation_lock = threading.Lock()
+        self.stop_event = threading.Event()
+        self.thread = None
+        self.state = "unknown"
+        self.checked_at = None
+        self.last_error = None
+        self.refreshing = False
+        self.changing = False
+
+    def start(self):
+        if not self.thread:
+            self.thread = threading.Thread(
+                target=self._loop, name=f"tuya-{self.entity}", daemon=True
+            )
+            self.thread.start()
+
+    def stop(self):
+        self.stop_event.set()
+
+    def snapshot(self):
+        with self.lock:
+            return {
+                "entity": self.entity,
+                "state": self.state,
+                "available": self.state in ("on", "off"),
+                "checked_at": self.checked_at,
+                "last_error": self.last_error,
+                "refreshing": self.refreshing,
+                "changing": self.changing,
+            }
+
+    def refresh(self):
+        with self.operation_lock:
+            return self._refresh()
+
+    def toggle(self):
+        with self.operation_lock:
+            with self.lock:
+                current = self.state
+                if current not in ("on", "off"):
+                    raise ValueError(f"{self.entity} status is unavailable")
+                desired = "off" if current == "on" else "on"
+                self.state = "unknown"
+                self.changing = True
+                self.last_error = None
+            try:
+                result = self.command([TUYA_TOGGLE, self.entity, desired], timeout=20)
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                message = f"could not turn {self.entity} {desired}: {exc}"
+                self._mark_unknown(message, changing=False)
+                raise RuntimeError(message) from exc
+            if result.returncode:
+                detail = (result.stderr or result.stdout or "command failed").strip()
+                message = f"could not turn {self.entity} {desired}: {detail[-300:]}"
+                self._mark_unknown(message, changing=False)
+                raise RuntimeError(message)
+
+            # Read the authoritative Tuya/HA state after the service call. If
+            # that verification fails, the UI returns to neutral grey rather
+            # than presenting the requested state as confirmed.
+            status = self._refresh()
+            if not status["available"]:
+                raise RuntimeError(f"{self.entity} changed but status verification failed")
+            return status
+
+    def _refresh(self):
+        with self.lock:
+            self.refreshing = True
+        try:
+            result = self.command([TUYA_STATUS, self.entity], timeout=20)
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            self._mark_unknown(f"could not read {self.entity}: {exc}", changing=False)
+        else:
+            state = result.stdout.strip().lower()
+            if result.returncode == 0 and state in ("on", "off"):
+                with self.lock:
+                    self.state = state
+                    self.checked_at = int(self.wall_clock())
+                    self.last_error = None
+                    self.refreshing = False
+                    self.changing = False
+            else:
+                detail = (result.stderr or result.stdout or "status unavailable").strip()
+                self._mark_unknown(f"could not read {self.entity}: {detail[-300:]}", changing=False)
+        return self.snapshot()
+
+    def _mark_unknown(self, message, changing):
+        with self.lock:
+            self.state = "unknown"
+            self.checked_at = int(self.wall_clock())
+            self.last_error = message
+            self.refreshing = False
+            self.changing = changing
+
+    def _loop(self):
+        while not self.stop_event.is_set():
+            self.refresh()
+            self.stop_event.wait(max(1.0, self.interval))
+
+
 class SonosController:
     """Small Sonos grouping/volume controller matching the audiobook page."""
 
@@ -807,6 +923,7 @@ cop_alert = CopAlertManager(state_store, engine_monitor)
 sonos = SonosController(state_store)
 connectivity = ConnectivityMonitor()
 speedtest = SpeedTestManager()
+starlink = TuyaSwitchManager("starlink")
 
 
 def api_error(message, status):
@@ -837,7 +954,26 @@ def reject_cross_origin_mutations():
 
 @app.route("/api/status")
 def api_status():
-    return jsonify({"ok": True, "cop_alert": cop_alert.snapshot()})
+    return jsonify(
+        {"ok": True, "cop_alert": cop_alert.snapshot(), "starlink": starlink.snapshot()}
+    )
+
+
+@app.route("/api/starlink", methods=["POST"])
+def api_starlink():
+    try:
+        status = starlink.toggle()
+    except ValueError as exc:
+        return api_error(exc, 503)
+    except RuntimeError as exc:
+        return api_error(exc, 502)
+    return jsonify(
+        {
+            "ok": True,
+            "message": f"Starlink power {status['state']}",
+            "starlink": status,
+        }
+    )
 
 
 @app.route("/api/connectivity")
@@ -943,27 +1079,30 @@ header{display:flex;align-items:center;justify-content:space-between;padding:24p
 .eyebrow{color:var(--accent);font-size:11px;font-weight:750;letter-spacing:.16em;text-transform:uppercase}
 h1{font-size:29px;line-height:1.05;letter-spacing:-.03em;margin:3px 0 0}.van-mark{font-size:28px;filter:grayscale(.2)}
 .connection{display:flex;align-items:center;gap:7px;color:var(--dim);font-size:12px;margin:0 2px 14px}
-.dot{width:8px;height:8px;border-radius:50%;background:var(--bad);box-shadow:0 0 0 3px #ef706718}
-.dot.on{background:var(--good);box-shadow:0 0 0 3px #62c89920}
+.dot{width:8px;height:8px;border-radius:50%;background:#71818a;box-shadow:0 0 0 3px #71818a18}
+.dot.on{background:var(--good);box-shadow:0 0 0 3px #62c89920}.dot.bad{background:var(--bad);box-shadow:0 0 0 3px #ef706718}
 .grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:11px}
 .tile{min-height:150px;border:1px solid var(--line);border-radius:19px;background:linear-gradient(145deg,var(--panel),#151f28);
   padding:15px;text-decoration:none;color:inherit;box-shadow:0 8px 28px #050b102e;display:flex;flex-direction:column;
   align-items:flex-start;text-align:left;cursor:pointer;position:relative;overflow:hidden}
 .tile:active{background:var(--raised);transform:scale(.985)}.tile-icon{font-size:31px;line-height:1;margin-bottom:auto}
 .tile-title{font-size:17px;font-weight:760;letter-spacing:-.01em}.tile-detail{font-size:12px;color:var(--dim);margin-top:3px;min-height:34px}
-.cop{grid-column:1/-1;min-height:210px;border-color:#744238;background:radial-gradient(circle at 92% 5%,#ef503f33,transparent 35%),linear-gradient(145deg,#292124,#1c2026)}
+.cop{min-height:210px;border-color:#744238;background:radial-gradient(circle at 92% 5%,#ef503f33,transparent 35%),linear-gradient(145deg,#292124,#1c2026)}
 .cop .tile-icon{font-size:38px}.cop .tile-title{font-size:23px}.cop::after{content:"";position:absolute;inset:auto -25% -80% 25%;height:180px;
   background:var(--alert);filter:blur(60px);opacity:0;transition:opacity .25s}.cop.active{border-color:#ef675a;box-shadow:0 10px 40px #ef503f25}
 .cop.active::after{opacity:.35}.cop.active .tile-title{color:#ffd7d2}.pill{position:absolute;right:14px;top:14px;border:1px solid var(--line);
   border-radius:99px;padding:4px 8px;font-size:10px;font-weight:800;letter-spacing:.1em;color:var(--dim);background:#10171dcc}
 .cop.active .pill{color:#fff1ef;background:#8b2d27;border-color:#bf473d}.status-lines{display:grid;gap:4px;margin-top:12px;width:100%;font-size:11px;color:var(--dim)}
 .status-line{display:flex;justify-content:space-between;gap:10px}.status-line span:last-child{text-align:right;color:#c5d1d7;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.starlink{min-height:210px;transition:border-color .2s,background .2s,opacity .2s}.starlink .tile-icon{font-size:38px}.starlink .tile-title{font-size:23px}.starlink.on{border-color:#438168;background:radial-gradient(circle at 88% 5%,#62c89928,transparent 38%),linear-gradient(145deg,#1d2b2b,#172225)}
+.starlink.off{border-color:#754743;background:radial-gradient(circle at 88% 5%,#ef70671c,transparent 38%),linear-gradient(145deg,#292124,#1b2025)}.starlink.unknown{border-color:#41505a;background:linear-gradient(145deg,#202a32,#182128)}.starlink:disabled{cursor:not-allowed;opacity:.72}
+.switch-state{position:absolute;right:14px;top:14px;display:flex;align-items:center;gap:7px;border:1px solid var(--line);border-radius:99px;padding:4px 8px;background:#10171dcc;color:var(--dim);font-size:10px;font-weight:800;letter-spacing:.08em}.starlink.on .switch-state{color:#bcebd5;border-color:#39725b}.starlink.off .switch-state{color:#f2b5b0;border-color:#754743}
 .connectivity{margin-top:11px;border:1px solid var(--line);border-radius:19px;background:linear-gradient(145deg,var(--panel),#151f28);padding:15px;box-shadow:0 8px 28px #050b102e}
 .connectivity-head{display:flex;align-items:baseline;justify-content:space-between;gap:12px;margin-bottom:13px}.connectivity-head h2{font-size:17px;margin:0;letter-spacing:-.01em}
 .connectivity-age{color:var(--dim);font-size:10px;text-align:right}.network-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:0}
 .network-stat{min-width:0;padding:1px 11px;border-left:1px solid var(--line)}.network-stat:first-child{border-left:0;padding-left:0}.network-stat:last-child{padding-right:0}
-.network-label{display:flex;align-items:center;gap:5px;color:var(--dim);font-size:10px;line-height:1.2;min-height:24px}.network-dot{width:7px;height:7px;flex:0 0 auto;border-radius:50%;background:#71818a}
-.network-dot.good{background:var(--good);box-shadow:0 0 0 3px #62c89918}.network-dot.bad{background:var(--bad);box-shadow:0 0 0 3px #ef706718}
+.network-label{display:flex;align-items:center;gap:7px;color:var(--dim);font-size:12px;line-height:1.2;min-height:24px}.network-dot{width:10px;height:10px;flex:0 0 auto;border-radius:50%;background:#71818a;box-shadow:0 0 0 4px #71818a18}
+.network-dot.good{background:var(--good);box-shadow:0 0 0 4px #62c89918}.network-dot.bad{background:var(--bad);box-shadow:0 0 0 4px #ef706718}
 .network-value{display:block;margin-top:4px;font-size:14px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.network-detail{display:block;margin-top:2px;color:var(--dim);font-size:9px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .mwan-list{display:flex;gap:5px;flex-wrap:wrap;margin-top:13px}.mwan-chip{border:1px solid #42545e;border-radius:99px;padding:3px 7px;color:var(--dim);font-size:9px}.mwan-chip.online{border-color:#39725b;color:#9cdec0;background:#1e3b31}.mwan-chip.offline{border-color:#6a4542;color:#e6aaa5;background:#392624}.mwan-chip.paused{opacity:.58}
 .speed-row{display:flex;align-items:center;gap:12px;margin-top:13px;padding-top:12px;border-top:1px solid var(--line)}.speedtest-button{display:flex;align-items:center;justify-content:center;gap:7px;flex:0 0 auto;border:1px solid #42606e;border-radius:11px;background:#263b47;color:var(--ink);padding:9px 11px;font-size:11px;font-weight:730;cursor:pointer}
@@ -997,6 +1136,11 @@ h1{font-size:29px;line-height:1.05;letter-spacing:-.03em;margin:3px 0 0}.van-mar
         <span class="status-line"><span>CAN wake</span><span id="wake">—</span></span>
       </span>
     </button>
+    <button class="tile starlink unknown" id="starlink" data-action disabled aria-pressed="mixed">
+      <span class="switch-state"><span class="network-dot" id="starlink-dot"></span><span id="starlink-state">NO DATA</span></span>
+      <span class="tile-icon" aria-hidden="true">🛰️</span><span class="tile-title">Starlink</span>
+      <span class="tile-detail" id="starlink-detail">Checking Tuya status…</span>
+    </button>
     <a class="tile" id="books" data-action href="#"><span class="tile-icon" aria-hidden="true">📖</span><span class="tile-title">Audiobooks</span><span class="tile-detail">Open the Sonos audiobook library</span></a>
     <button class="tile" id="speakers" data-action aria-haspopup="dialog" aria-expanded="false" aria-controls="speaker-panel">
       <span class="tile-icon" aria-hidden="true">🔊</span><span class="tile-title">Sonos</span><span class="tile-detail" id="speaker-summary">Finding speakers…</span>
@@ -1005,8 +1149,8 @@ h1{font-size:29px;line-height:1.05;letter-spacing:-.03em;margin:3px 0 0}.van-mar
   <section class="connectivity" aria-labelledby="connectivity-title">
     <div class="connectivity-head"><h2 id="connectivity-title">Connectivity</h2><span class="connectivity-age" id="connectivity-age">Checking…</span></div>
     <div class="network-grid">
-      <div class="network-stat"><span class="network-label"><span class="network-dot" id="internet-dot"></span>Internet Connectivity</span><strong class="network-value" id="internet-status">Checking…</strong><span class="network-detail" id="mwan-primary">mwan3 mode · —</span></div>
-      <div class="network-stat"><span class="network-label"><span class="network-dot" id="ubnt-dot"></span>UBNT Availability</span><strong class="network-value" id="ubnt-status">Checking…</strong><span class="network-detail" id="ubnt-detail">Ethernet · —</span></div>
+      <div class="network-stat"><span class="network-label"><span class="network-dot" id="internet-dot"></span>MWAN3</span><strong class="network-value" id="mwan-mode">Checking…</strong></div>
+      <div class="network-stat"><span class="network-label"><span class="network-dot" id="ubnt-dot"></span>UBNT Availability</span></div>
       <div class="network-stat"><span class="network-label"><span class="network-dot" id="wireless-dot"></span>UBNT Wireless</span><strong class="network-value" id="wireless-status">Checking…</strong><span class="network-detail" id="wireless-detail">Association · —</span></div>
     </div>
     <div class="mwan-list" id="mwan-list" aria-label="mwan3 interfaces"></div>
@@ -1036,10 +1180,8 @@ async function action(work){if(busy)return;busy=true;document.body.classList.add
 function age(ts){if(!ts)return 'never';const secs=Math.max(0,Date.now()/1000-ts);return secs<90?`${Math.round(secs)}s ago`:`${Math.round(secs/60)}m ago`}
 function networkState(id,value){const el=$(id);el.classList.remove('good','bad');if(value===true)el.classList.add('good');else if(value===false)el.classList.add('bad')}
 function renderConnectivity(response){const c=response.connectivity,r=c.router||{},u=c.ubnt||{},online=c.internet?.online;
-  networkState('internet-dot',online);$('internet-status').textContent=online===true?'Online':online===false?'Offline':'Unknown';
-  $('mwan-primary').textContent=r.reachable===false?'mwan3 · router unavailable':r.mode?`mwan3 mode · ${r.mode}`:r.reachable===true?'mwan3 · no active uplink':'mwan3 mode · —';
-  networkState('ubnt-dot',u.reachable);$('ubnt-status').textContent=u.reachable===true?'Reachable':u.reachable===false?'Unavailable':'Unknown';
-  $('ubnt-detail').textContent=u.reachable===false?'Ethernet cable or power':u.reachable===true?'Ethernet link responds':'Ethernet · —';
+  networkState('internet-dot',online===null&&r.reachable===false?false:online);$('mwan-mode').textContent=r.mode||((online===false||r.reachable===false)?'No active uplink':'Unknown');
+  networkState('ubnt-dot',u.reachable);$('ubnt-dot').closest('.network-stat').title=u.error||'';
   const radioKnown=u.reachable===true&&!u.error;networkState('wireless-dot',radioKnown?u.connected:u.reachable===false?false:null);
   if(u.reachable===false){$('wireless-status').textContent='Unavailable';$('wireless-detail').textContent='No UBNT Ethernet response'}
   else if(u.error){$('wireless-status').textContent='Status error';$('wireless-detail').textContent='Could not read radio'}
@@ -1056,13 +1198,14 @@ function renderSpeedtest(response){const s=response.speedtest,button=$('speedtes
   else $('speed-results').innerHTML="<strong>Not run yet</strong>Uses vanpi's current route"}
 async function refreshSpeedtest(){clearTimeout(speedPoll);try{const response=await json('/api/speedtest');renderSpeedtest(response);if(response.speedtest.status==='running')speedPoll=setTimeout(refreshSpeedtest,1000)}catch(error){$('speed-results').innerHTML=`<strong>Speed test unavailable</strong>${esc(error.message)}`}}
 async function startSpeedtest(){if($('speedtest-button').disabled)return;$('speedtest-button').disabled=true;try{const response=await post('speedtest');renderSpeedtest(response);if(response.speedtest.status==='running')speedPoll=setTimeout(refreshSpeedtest,1000)}catch(error){toast(error.message,true);$('speedtest-button').disabled=false}}
-function updateStatus(data){dashboard=data.cop_alert;const active=dashboard.active,engine=dashboard.engine;$('dot').classList.add('on');$('connection').textContent='Connected · vanpi dashboard';
+function renderStarlink(status){const state=status?.state||'unknown',known=state==='on'||state==='off',tile=$('starlink');tile.classList.remove('on','off','unknown');tile.classList.add(known?state:'unknown');networkState('starlink-dot',state==='on'?true:state==='off'?false:null);tile.disabled=!known||Boolean(status?.changing);tile.setAttribute('aria-pressed',known?String(state==='on'):'mixed');$('starlink-state').textContent=status?.changing?'WAIT':state==='on'?'ON':state==='off'?'OFF':'NO DATA';$('starlink-detail').textContent=status?.changing?'Changing power…':state==='on'?'Tuya switch is on':state==='off'?'Tuya switch is off':'Tuya status unavailable'}
+function updateStatus(data){dashboard=data.cop_alert;const active=dashboard.active,engine=dashboard.engine;$('dot').classList.remove('bad');$('dot').classList.add('on');$('connection').textContent='Connected · vanpi dashboard';renderStarlink(data.starlink);
   $('cop').classList.toggle('active',active);$('cop').setAttribute('aria-pressed',String(active));$('cop-pill').textContent=active?'ACTIVE':'OFF';
   $('cop-detail').textContent=active?'Dashcam wake and 5-minute bacon alerts are active':'Tap to keep the dashcam awake';
   $('engine').textContent=engine.running?`RUNNING · ${Math.round(engine.rpm)} RPM`:engine.rpm===null?'No fresh data':`Stopped · ${Math.round(engine.rpm)} RPM`;
   $('flood').textContent=dashboard.ext_flood;$('wake').textContent=dashboard.last_wake_ok===null?'Not attempted':dashboard.last_wake_ok?`OK · ${age(dashboard.last_wake)}`:'DEGRADED';
   if(active&&dashboard.last_error)$('connection').textContent=`Active with warning · ${dashboard.last_error}`}
-async function refresh(){try{updateStatus(await json('/api/status'))}catch(error){$('dot').classList.remove('on');$('connection').textContent=error.message}}
+async function refresh(){try{updateStatus(await json('/api/status'))}catch(error){$('dot').classList.remove('on');$('dot').classList.add('bad');$('connection').textContent=error.message}}
 function renderSpeakers(next){speakers=next;const grouped=next.speakers.filter(s=>s.grouped);$('speaker-summary').textContent=`${next.coordinator} · ${grouped.length}/${next.speakers.length} grouped`;
   $('speaker-list').innerHTML=next.speakers.map(s=>{const detail=s.coordinator?'Active coordinator':s.grouped?`Grouped with ${next.coordinator}`:`Group: ${s.group_coordinator}`;
     const volume=Number.isFinite(s.volume)?s.volume:0;return `<div class="speaker-row"><input class="speaker-check" data-action data-group-speaker="${esc(s.name)}" type="checkbox" ${s.grouped?'checked':''} ${s.coordinator?'disabled':''} aria-label="Group ${esc(s.name)}">
@@ -1073,7 +1216,7 @@ async function openSpeakers(){$('speaker-backdrop').classList.add('open');docume
   try{await loadSpeakers()}catch(error){$('speaker-list').innerHTML=`<div class="speaker-loading">${esc(error.message)}</div>`;toast(error.message,true)}}
 function closeSpeakers(){$('speaker-backdrop').classList.remove('open');document.body.classList.remove('sheet-open');$('speakers').setAttribute('aria-expanded','false');$('speakers').focus()}
 const bookUrl=new URL(window.location.href);bookUrl.port='8787';bookUrl.pathname='/';bookUrl.search='';bookUrl.hash='';$('books').href=bookUrl.toString();
-$('cop').addEventListener('click',()=>action(()=>post('cop-alert',{active:dashboard?.active?'false':'true'})));$('speakers').addEventListener('click',openSpeakers);$('speaker-close').addEventListener('click',closeSpeakers);
+$('cop').addEventListener('click',()=>action(()=>post('cop-alert',{active:dashboard?.active?'false':'true'})));$('starlink').addEventListener('click',()=>{renderStarlink({state:'unknown',changing:true});action(()=>post('starlink'))});$('speakers').addEventListener('click',openSpeakers);$('speaker-close').addEventListener('click',closeSpeakers);
 $('speedtest-button').addEventListener('click',startSpeedtest);
 $('speaker-backdrop').addEventListener('click',event=>{if(event.target===$('speaker-backdrop'))closeSpeakers()});document.addEventListener('keydown',event=>{if(event.key==='Escape')closeSpeakers()});
 document.addEventListener('input',event=>{const slider=event.target.closest('[data-speaker-volume]');if(slider)slider.closest('.speaker-row').querySelector('.speaker-level').textContent=slider.value});
@@ -1128,4 +1271,5 @@ def index():
 if __name__ == "__main__":
     cop_alert.start()
     connectivity.start()
+    starlink.start()
     app.run(host="0.0.0.0", port=PORT, threaded=True)

--- a/automation/van_dashboard.py
+++ b/automation/van_dashboard.py
@@ -40,6 +40,7 @@ ENGINE_MARKER = os.path.join(RUNTIME_DIR, "engine-running")
 TUYA_TOGGLE = os.environ.get("VAN_DASHBOARD_TUYA_TOGGLE", "/home/pi/scripts/tuya_toggle.sh")
 TUYA_STATUS = os.environ.get("VAN_DASHBOARD_TUYA_STATUS", "/home/pi/scripts/tuya_status.sh")
 NTFY_SEND = os.environ.get("VAN_DASHBOARD_NTFY_SEND", "/home/pi/scripts/ntfy_send.sh")
+TUYA_LIGHT = os.environ.get("VAN_DASHBOARD_TUYA_LIGHT", "/home/pi/scripts/tuya_light.sh")
 CONNECTIVITY_STATUS = os.environ.get(
     "VAN_DASHBOARD_CONNECTIVITY_STATUS", "/home/pi/scripts/connectivity_status.py"
 )
@@ -49,6 +50,19 @@ SPEEDTEST = os.path.expanduser(
 CONNECTIVITY_INTERVAL = float(os.environ.get("VAN_DASHBOARD_CONNECTIVITY_INTERVAL", "30"))
 SPEEDTEST_TIMEOUT = float(os.environ.get("VAN_DASHBOARD_SPEEDTEST_TIMEOUT", "180"))
 TUYA_POLL_INTERVAL = float(os.environ.get("VAN_DASHBOARD_TUYA_POLL_INTERVAL", "15"))
+COP_LED_SOURCE = os.environ.get("VAN_DASHBOARD_COP_LED_SOURCE", "light.solder_led")
+COP_LED_TARGET = os.environ.get("VAN_DASHBOARD_COP_LED_TARGET", "light.ext_led")
+COP_LED_FALLBACK_BRIGHTNESS = int(
+    os.environ.get("VAN_DASHBOARD_COP_LED_FALLBACK_BRIGHTNESS", "170")
+)
+COP_LED_FALLBACK_KELVIN = int(
+    os.environ.get("VAN_DASHBOARD_COP_LED_FALLBACK_KELVIN", "2702")
+)
+COP_LED_RETRY_INTERVAL = float(os.environ.get("VAN_DASHBOARD_COP_LED_RETRY_INTERVAL", "5"))
+COP_LED_VERIFY_INTERVAL = float(
+    os.environ.get("VAN_DASHBOARD_COP_LED_VERIFY_INTERVAL", "30")
+)
+COP_LED_CONNECT_GRACE = float(os.environ.get("VAN_DASHBOARD_COP_LED_CONNECT_GRACE", "90"))
 
 CAN_CHANNEL = os.environ.get("VAN_DASHBOARD_CAN_CHANNEL", "can0")
 CAN_BITRATE = 500000
@@ -508,6 +522,295 @@ class CopAlertManager:
             pass
 
 
+class CopLedManager:
+    """Apply and verify the COP ALERT exterior LED look off-thread."""
+
+    def __init__(
+        self,
+        store,
+        engine_monitor=None,
+        source=COP_LED_SOURCE,
+        target=COP_LED_TARGET,
+        command=run_command,
+        clock=time.monotonic,
+        wall_clock=time.time,
+        retry_interval=COP_LED_RETRY_INTERVAL,
+        verify_interval=COP_LED_VERIFY_INTERVAL,
+        connect_grace=COP_LED_CONNECT_GRACE,
+        fallback_brightness=COP_LED_FALLBACK_BRIGHTNESS,
+        fallback_kelvin=COP_LED_FALLBACK_KELVIN,
+    ):
+        self.store = store
+        self.engine_monitor = engine_monitor
+        self.source = source
+        self.target = target
+        self.command = command
+        self.clock = clock
+        self.wall_clock = wall_clock
+        self.retry_interval = retry_interval
+        self.verify_interval = verify_interval
+        self.connect_grace = connect_grace
+        self.fallback = {
+            "brightness": fallback_brightness,
+            "color_temp_kelvin": fallback_kelvin,
+        }
+        self.lock = threading.Lock()
+        self.stop_event = threading.Event()
+        self.wake_event = threading.Event()
+        self.thread = None
+        self.was_active = False
+        self.connect_started_at = None
+        self.next_attempt = 0.0
+        self.desired = None
+        self.reference = None
+        self.phase = "inactive"
+        self.message = "COP ALERT is off"
+        self.last_error = None
+        self.last_attempt = None
+        self.confirmed_at = None
+
+    def start(self):
+        if not self.thread:
+            self.thread = threading.Thread(
+                target=self._loop, name="cop-alert-ext-led", daemon=True
+            )
+            self.thread.start()
+
+    def stop(self):
+        self.stop_event.set()
+        self.wake_event.set()
+
+    def notify(self):
+        with self.lock:
+            self.next_attempt = 0.0
+        self.wake_event.set()
+
+    def snapshot(self):
+        with self.lock:
+            return {
+                "phase": self.phase,
+                "message": self.message,
+                "last_error": self.last_error,
+                "last_attempt": self.last_attempt,
+                "confirmed_at": self.confirmed_at,
+                "desired": copy.deepcopy(self.desired),
+                "reference": self.reference,
+                "source": self.source,
+                "target": self.target,
+            }
+
+    def tick(self):
+        now = self.clock()
+        active = bool(self.store.get("cop_alert", False))
+        with self.lock:
+            if not active:
+                self.was_active = False
+                self.connect_started_at = None
+                self.next_attempt = 0.0
+                self.desired = None
+                self.reference = None
+                self.phase = "inactive"
+                self.message = "COP ALERT is off"
+                self.last_error = None
+                self.confirmed_at = None
+                return self.snapshot_unlocked()
+            if not self.was_active:
+                self.was_active = True
+                self.connect_started_at = now
+                self.next_attempt = 0.0
+                self.desired = None
+                self.reference = None
+                self.phase = "preparing"
+                self.message = "Preparing ext_led"
+                self.last_error = None
+                self.confirmed_at = None
+            if now < self.next_attempt:
+                return self.snapshot_unlocked()
+            self.last_attempt = int(self.wall_clock())
+
+        if self.engine_monitor is not None and self.engine_monitor.snapshot()["running"]:
+            with self.lock:
+                self.connect_started_at = None
+            self._schedule(
+                "paused",
+                "Engine running · ext_flood is intentionally off",
+                None,
+                now + self.retry_interval,
+            )
+            return self.snapshot()
+
+        with self.lock:
+            if self.connect_started_at is None:
+                self.connect_started_at = now
+
+        with self.lock:
+            desired = copy.deepcopy(self.desired)
+        if desired is None:
+            source_status, source_error = self._read_light(self.source)
+            desired = self._settings_from_status(source_status)
+            reference = self.source
+            if desired is None:
+                desired = dict(self.fallback)
+                reference = "captured solder_led fallback"
+            with self.lock:
+                self.desired = desired
+                self.reference = reference
+                if source_error:
+                    self.message = "Reference unavailable; using captured settings"
+
+        target_status, target_error = self._read_light(self.target)
+        if target_error or not target_status or target_status.get("state") == "unavailable":
+            with self.lock:
+                waiting_for = now - self.connect_started_at
+            if waiting_for >= self.connect_grace:
+                message = "ext_led unavailable · still retrying"
+                error = target_error or (
+                    f"{self.target} did not join Wi-Fi within {self.connect_grace:g} seconds"
+                )
+                phase = "unavailable"
+            else:
+                message = "Waiting for ext_led Wi-Fi"
+                error = target_error
+                phase = "waiting"
+            self._schedule(phase, message, error, now + self.retry_interval)
+            return self.snapshot()
+
+        if self._matches(target_status, desired):
+            self._confirmed(desired, now)
+            return self.snapshot()
+
+        with self.lock:
+            self.phase = "applying"
+            self.message = "Applying ext_led brightness and color"
+            self.last_error = None
+        set_error = self._set_light(self.target, desired)
+        if set_error:
+            self._schedule(
+                "error", "Could not configure ext_led; retrying", set_error, now + self.retry_interval
+            )
+            return self.snapshot()
+
+        confirmed, confirm_error = self._read_light(self.target)
+        if confirmed and self._matches(confirmed, desired):
+            self._confirmed(desired, now)
+        elif confirm_error or not confirmed or confirmed.get("state") == "unavailable":
+            self._schedule(
+                "waiting",
+                "ext_led accepted settings; waiting for Wi-Fi confirmation",
+                confirm_error,
+                now + self.retry_interval,
+            )
+        else:
+            self._schedule(
+                "verifying",
+                "ext_led settings not confirmed yet; retrying",
+                None,
+                now + self.retry_interval,
+            )
+        return self.snapshot()
+
+    def snapshot_unlocked(self):
+        return {
+            "phase": self.phase,
+            "message": self.message,
+            "last_error": self.last_error,
+            "last_attempt": self.last_attempt,
+            "confirmed_at": self.confirmed_at,
+            "desired": copy.deepcopy(self.desired),
+            "reference": self.reference,
+            "source": self.source,
+            "target": self.target,
+        }
+
+    def _read_light(self, entity):
+        try:
+            result = self.command([TUYA_LIGHT, "status", entity], timeout=20)
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return None, f"could not read {entity}: {exc}"
+        if result.returncode:
+            detail = (result.stderr or result.stdout or "status failed").strip()
+            return None, f"could not read {entity}: {detail[-300:]}"
+        try:
+            status = json.loads(result.stdout)
+        except (TypeError, ValueError):
+            return None, f"could not read {entity}: invalid status response"
+        return status if isinstance(status, dict) else None, None
+
+    @staticmethod
+    def _settings_from_status(status):
+        if not status:
+            return None
+        try:
+            brightness = int(status["brightness"])
+            kelvin = int(status["color_temp_kelvin"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        if not 1 <= brightness <= 255 or not 2000 <= kelvin <= 7000:
+            return None
+        return {"brightness": brightness, "color_temp_kelvin": kelvin}
+
+    @staticmethod
+    def _matches(status, desired):
+        if not status or status.get("state") != "on":
+            return False
+        try:
+            brightness = int(status.get("brightness"))
+            kelvin = int(status.get("color_temp_kelvin"))
+        except (TypeError, ValueError):
+            return False
+        return brightness == desired["brightness"] and abs(
+            kelvin - desired["color_temp_kelvin"]
+        ) <= 10
+
+    def _set_light(self, entity, desired):
+        try:
+            result = self.command(
+                [
+                    TUYA_LIGHT,
+                    "set",
+                    entity,
+                    str(desired["brightness"]),
+                    str(desired["color_temp_kelvin"]),
+                ],
+                timeout=20,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return f"could not set {entity}: {exc}"
+        if result.returncode:
+            detail = (result.stderr or result.stdout or "set failed").strip()
+            return f"could not set {entity}: {detail[-300:]}"
+        return None
+
+    def _schedule(self, phase, message, error, next_attempt):
+        with self.lock:
+            self.phase = phase
+            self.message = message
+            self.last_error = error
+            self.next_attempt = next_attempt
+
+    def _confirmed(self, desired, now):
+        percent = round(desired["brightness"] * 100 / 255)
+        with self.lock:
+            self.phase = "confirmed"
+            self.message = f"Matched · {percent}% · {desired['color_temp_kelvin']} K"
+            self.last_error = None
+            self.confirmed_at = int(self.wall_clock())
+            self.next_attempt = now + self.verify_interval
+
+    def _loop(self):
+        while not self.stop_event.is_set():
+            try:
+                self.tick()
+            except Exception as exc:
+                with self.lock:
+                    self.phase = "error"
+                    self.message = "ext_led manager failed; retrying"
+                    self.last_error = str(exc)
+                    self.next_attempt = self.clock() + self.retry_interval
+            self.wake_event.wait(1.0)
+            self.wake_event.clear()
+
+
 class TuyaSwitchManager:
     """Cache and safely toggle one Home Assistant/Tuya switch."""
 
@@ -920,6 +1223,7 @@ app = Flask(__name__)
 state_store = StateStore()
 engine_monitor = EngineMonitor()
 cop_alert = CopAlertManager(state_store, engine_monitor)
+cop_led = CopLedManager(state_store, engine_monitor)
 sonos = SonosController(state_store)
 connectivity = ConnectivityMonitor()
 speedtest = SpeedTestManager()
@@ -955,7 +1259,12 @@ def reject_cross_origin_mutations():
 @app.route("/api/status")
 def api_status():
     return jsonify(
-        {"ok": True, "cop_alert": cop_alert.snapshot(), "starlink": starlink.snapshot()}
+        {
+            "ok": True,
+            "cop_alert": cop_alert.snapshot(),
+            "cop_led": cop_led.snapshot(),
+            "starlink": starlink.snapshot(),
+        }
     )
 
 
@@ -997,6 +1306,7 @@ def api_cop_alert():
         return api_error("active must be true or false", 400)
     active = raw in ("1", "true", "on")
     status = cop_alert.set_active(active)
+    cop_led.notify()
     verb = "armed" if active else "disarmed"
     return jsonify({"ok": True, "message": f"COP ALERT {verb}", "cop_alert": status})
 
@@ -1133,6 +1443,7 @@ h1{font-size:29px;line-height:1.05;letter-spacing:-.03em;margin:3px 0 0}.van-mar
       <span class="status-lines">
         <span class="status-line"><span>Engine</span><span id="engine">Checking C-CAN…</span></span>
         <span class="status-line"><span>ext_flood</span><span id="flood">—</span></span>
+        <span class="status-line"><span>ext_led</span><span id="cop-led">—</span></span>
         <span class="status-line"><span>CAN wake</span><span id="wake">—</span></span>
       </span>
     </button>
@@ -1199,11 +1510,11 @@ function renderSpeedtest(response){const s=response.speedtest,button=$('speedtes
 async function refreshSpeedtest(){clearTimeout(speedPoll);try{const response=await json('/api/speedtest');renderSpeedtest(response);if(response.speedtest.status==='running')speedPoll=setTimeout(refreshSpeedtest,1000)}catch(error){$('speed-results').innerHTML=`<strong>Speed test unavailable</strong>${esc(error.message)}`}}
 async function startSpeedtest(){if($('speedtest-button').disabled)return;$('speedtest-button').disabled=true;try{const response=await post('speedtest');renderSpeedtest(response);if(response.speedtest.status==='running')speedPoll=setTimeout(refreshSpeedtest,1000)}catch(error){toast(error.message,true);$('speedtest-button').disabled=false}}
 function renderStarlink(status){const state=status?.state||'unknown',known=state==='on'||state==='off',tile=$('starlink');tile.classList.remove('on','off','unknown');tile.classList.add(known?state:'unknown');networkState('starlink-dot',state==='on'?true:state==='off'?false:null);tile.disabled=!known||Boolean(status?.changing);tile.setAttribute('aria-pressed',known?String(state==='on'):'mixed');$('starlink-state').textContent=status?.changing?'WAIT':state==='on'?'ON':state==='off'?'OFF':'NO DATA';$('starlink-detail').textContent=status?.changing?'Changing power…':state==='on'?'Tuya switch is on':state==='off'?'Tuya switch is off':'Tuya status unavailable'}
-function updateStatus(data){dashboard=data.cop_alert;const active=dashboard.active,engine=dashboard.engine;$('dot').classList.remove('bad');$('dot').classList.add('on');$('connection').textContent='Connected · vanpi dashboard';renderStarlink(data.starlink);
+function updateStatus(data){dashboard=data.cop_alert;const active=dashboard.active,engine=dashboard.engine,led=data.cop_led||{};$('dot').classList.remove('bad');$('dot').classList.add('on');$('connection').textContent='Connected · vanpi dashboard';renderStarlink(data.starlink);
   $('cop').classList.toggle('active',active);$('cop').setAttribute('aria-pressed',String(active));$('cop-pill').textContent=active?'ACTIVE':'OFF';
   $('cop-detail').textContent=active?'Dashcam wake and 5-minute bacon alerts are active':'Tap to keep the dashcam awake';
   $('engine').textContent=engine.running?`RUNNING · ${Math.round(engine.rpm)} RPM`:engine.rpm===null?'No fresh data':`Stopped · ${Math.round(engine.rpm)} RPM`;
-  $('flood').textContent=dashboard.ext_flood;$('wake').textContent=dashboard.last_wake_ok===null?'Not attempted':dashboard.last_wake_ok?`OK · ${age(dashboard.last_wake)}`:'DEGRADED';
+  $('flood').textContent=dashboard.ext_flood;$('cop-led').textContent=led.message||'No data';$('cop-led').title=led.last_error||'';$('wake').textContent=dashboard.last_wake_ok===null?'Not attempted':dashboard.last_wake_ok?`OK · ${age(dashboard.last_wake)}`:'DEGRADED';
   if(active&&dashboard.last_error)$('connection').textContent=`Active with warning · ${dashboard.last_error}`}
 async function refresh(){try{updateStatus(await json('/api/status'))}catch(error){$('dot').classList.remove('on');$('dot').classList.add('bad');$('connection').textContent=error.message}}
 function renderSpeakers(next){speakers=next;const grouped=next.speakers.filter(s=>s.grouped);$('speaker-summary').textContent=`${next.coordinator} · ${grouped.length}/${next.speakers.length} grouped`;
@@ -1270,6 +1581,7 @@ def index():
 
 if __name__ == "__main__":
     cop_alert.start()
+    cop_led.start()
     connectivity.start()
     starlink.start()
     app.run(host="0.0.0.0", port=PORT, threaded=True)

--- a/automation/van_dashboard.py
+++ b/automation/van_dashboard.py
@@ -15,6 +15,7 @@ bring can0 up/down or change its bitrate/listen-only state because the interface
 is shared with other vehicle tooling.
 """
 
+import copy
 import json
 import os
 import re
@@ -39,6 +40,14 @@ ENGINE_MARKER = os.path.join(RUNTIME_DIR, "engine-running")
 TUYA_TOGGLE = os.environ.get("VAN_DASHBOARD_TUYA_TOGGLE", "/home/pi/scripts/tuya_toggle.sh")
 TUYA_STATUS = os.environ.get("VAN_DASHBOARD_TUYA_STATUS", "/home/pi/scripts/tuya_status.sh")
 NTFY_SEND = os.environ.get("VAN_DASHBOARD_NTFY_SEND", "/home/pi/scripts/ntfy_send.sh")
+CONNECTIVITY_STATUS = os.environ.get(
+    "VAN_DASHBOARD_CONNECTIVITY_STATUS", "/home/pi/scripts/connectivity_status.py"
+)
+SPEEDTEST = os.path.expanduser(
+    os.environ.get("VAN_DASHBOARD_SPEEDTEST", "/home/pi/scripts/speedtest.sh")
+)
+CONNECTIVITY_INTERVAL = float(os.environ.get("VAN_DASHBOARD_CONNECTIVITY_INTERVAL", "30"))
+SPEEDTEST_TIMEOUT = float(os.environ.get("VAN_DASHBOARD_SPEEDTEST_TIMEOUT", "180"))
 
 CAN_CHANNEL = os.environ.get("VAN_DASHBOARD_CAN_CHANNEL", "can0")
 CAN_BITRATE = 500000
@@ -608,11 +617,196 @@ class SonosController:
         return volume
 
 
+class ConnectivityMonitor:
+    """Cache the reusable connectivity collector away from HTTP request threads."""
+
+    def __init__(
+        self,
+        collector=CONNECTIVITY_STATUS,
+        interval=CONNECTIVITY_INTERVAL,
+        command=run_command,
+        clock=time.monotonic,
+        wall_clock=time.time,
+    ):
+        self.collector = collector
+        self.interval = interval
+        self.command = command
+        self.clock = clock
+        self.wall_clock = wall_clock
+        self.lock = threading.Lock()
+        self.stop_event = threading.Event()
+        self.thread = None
+        self.refreshing = False
+        self.last_error = None
+        self.data = {
+            "checked_at": None,
+            "internet": {"online": None, "source": "mwan3 reachability tracking"},
+            "router": {
+                "reachable": None,
+                "mode": None,
+                "online": [],
+                "interfaces": [],
+                "error": None,
+            },
+            "ubnt": {
+                "reachable": None,
+                "connected": None,
+                "ssid": None,
+                "signal_dbm": None,
+                "noise_dbm": None,
+                "quality_percent": None,
+                "ccq_percent": None,
+                "bitrate": None,
+                "error": None,
+            },
+        }
+
+    def start(self):
+        if not self.thread:
+            self.thread = threading.Thread(
+                target=self._loop, name="connectivity-monitor", daemon=True
+            )
+            self.thread.start()
+
+    def stop(self):
+        self.stop_event.set()
+
+    def refresh(self):
+        with self.lock:
+            self.refreshing = True
+        try:
+            result = self.command([self.collector], timeout=25)
+            if result.returncode:
+                detail = (result.stderr or result.stdout or "collector failed").strip()
+                raise RuntimeError(detail[-300:])
+            payload = json.loads(result.stdout)
+            if not isinstance(payload, dict) or not all(
+                key in payload for key in ("checked_at", "internet", "router", "ubnt")
+            ):
+                raise ValueError("collector returned an incomplete payload")
+        except (OSError, ValueError, RuntimeError, subprocess.TimeoutExpired) as exc:
+            with self.lock:
+                self.last_error = str(exc)
+        else:
+            with self.lock:
+                self.data = payload
+                self.last_error = None
+        finally:
+            with self.lock:
+                self.refreshing = False
+        return self.snapshot()
+
+    def snapshot(self):
+        with self.lock:
+            data = copy.deepcopy(self.data)
+            data["refreshing"] = self.refreshing
+            data["last_error"] = self.last_error
+        checked_at = data.get("checked_at")
+        data["stale"] = checked_at is None or (
+            self.wall_clock() - checked_at > max(60.0, self.interval * 2.5)
+        )
+        return data
+
+    def _loop(self):
+        while not self.stop_event.is_set():
+            started = self.clock()
+            self.refresh()
+            remaining = max(1.0, self.interval - (self.clock() - started))
+            self.stop_event.wait(remaining)
+
+
+def parse_speedtest_output(output):
+    values = {}
+    patterns = {
+        "download_mbps": r"^Download(?: Speed)?:\s*([0-9.]+)\s*(?:Mbit/s|Mbps)",
+        "upload_mbps": r"^Upload(?: Speed)?:\s*([0-9.]+)\s*(?:Mbit/s|Mbps)",
+        "latency_ms": r"^(?:Ping|Latency):\s*([0-9.]+)\s*ms",
+    }
+    for name, pattern in patterns.items():
+        match = re.search(pattern, output, re.IGNORECASE | re.MULTILINE)
+        if match:
+            values[name] = float(match.group(1))
+    return values
+
+
+class SpeedTestManager:
+    """Run the existing speedtest script once at a time, outside request threads."""
+
+    def __init__(
+        self,
+        script=SPEEDTEST,
+        command=run_command,
+        timeout=SPEEDTEST_TIMEOUT,
+        wall_clock=time.time,
+    ):
+        self.script = script
+        self.command = command
+        self.timeout = timeout
+        self.wall_clock = wall_clock
+        self.lock = threading.Lock()
+        self.thread = None
+        self.data = {
+            "status": "idle",
+            "started_at": None,
+            "completed_at": None,
+            "download_mbps": None,
+            "upload_mbps": None,
+            "latency_ms": None,
+            "error": None,
+        }
+
+    def start(self):
+        with self.lock:
+            if self.data["status"] == "running":
+                return False
+            self.data = {
+                "status": "running",
+                "started_at": int(self.wall_clock()),
+                "completed_at": None,
+                "download_mbps": None,
+                "upload_mbps": None,
+                "latency_ms": None,
+                "error": None,
+            }
+            self.thread = threading.Thread(target=self._run, name="speedtest", daemon=True)
+            self.thread.start()
+            return True
+
+    def snapshot(self):
+        with self.lock:
+            return dict(self.data)
+
+    def _run(self):
+        error = None
+        values = {}
+        try:
+            result = self.command([self.script], timeout=self.timeout)
+            if result.returncode:
+                detail = (result.stderr or result.stdout or "speed test failed").strip()
+                error = detail[-500:]
+            else:
+                values = parse_speedtest_output(result.stdout)
+                if len(values) != 3:
+                    error = "speed test returned incomplete results"
+        except subprocess.TimeoutExpired:
+            error = f"speed test timed out after {self.timeout:g} seconds"
+        except OSError as exc:
+            error = f"could not start speed test: {exc}"
+
+        with self.lock:
+            self.data.update(values)
+            self.data["status"] = "error" if error else "complete"
+            self.data["completed_at"] = int(self.wall_clock())
+            self.data["error"] = error
+
+
 app = Flask(__name__)
 state_store = StateStore()
 engine_monitor = EngineMonitor()
 cop_alert = CopAlertManager(state_store, engine_monitor)
 sonos = SonosController(state_store)
+connectivity = ConnectivityMonitor()
+speedtest = SpeedTestManager()
 
 
 def api_error(message, status):
@@ -644,6 +838,20 @@ def reject_cross_origin_mutations():
 @app.route("/api/status")
 def api_status():
     return jsonify({"ok": True, "cop_alert": cop_alert.snapshot()})
+
+
+@app.route("/api/connectivity")
+def api_connectivity():
+    return jsonify({"ok": True, "connectivity": connectivity.snapshot()})
+
+
+@app.route("/api/speedtest", methods=["GET", "POST"])
+def api_speedtest():
+    if request.method == "POST":
+        started = speedtest.start()
+        message = "Speed test started" if started else "Speed test is already running"
+        return jsonify({"ok": True, "message": message, "speedtest": speedtest.snapshot()})
+    return jsonify({"ok": True, "speedtest": speedtest.snapshot()})
 
 
 @app.route("/api/cop-alert", methods=["POST"])
@@ -750,6 +958,17 @@ h1{font-size:29px;line-height:1.05;letter-spacing:-.03em;margin:3px 0 0}.van-mar
   border-radius:99px;padding:4px 8px;font-size:10px;font-weight:800;letter-spacing:.1em;color:var(--dim);background:#10171dcc}
 .cop.active .pill{color:#fff1ef;background:#8b2d27;border-color:#bf473d}.status-lines{display:grid;gap:4px;margin-top:12px;width:100%;font-size:11px;color:var(--dim)}
 .status-line{display:flex;justify-content:space-between;gap:10px}.status-line span:last-child{text-align:right;color:#c5d1d7;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.connectivity{margin-top:11px;border:1px solid var(--line);border-radius:19px;background:linear-gradient(145deg,var(--panel),#151f28);padding:15px;box-shadow:0 8px 28px #050b102e}
+.connectivity-head{display:flex;align-items:baseline;justify-content:space-between;gap:12px;margin-bottom:13px}.connectivity-head h2{font-size:17px;margin:0;letter-spacing:-.01em}
+.connectivity-age{color:var(--dim);font-size:10px;text-align:right}.network-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:0}
+.network-stat{min-width:0;padding:1px 11px;border-left:1px solid var(--line)}.network-stat:first-child{border-left:0;padding-left:0}.network-stat:last-child{padding-right:0}
+.network-label{display:flex;align-items:center;gap:5px;color:var(--dim);font-size:10px;line-height:1.2;min-height:24px}.network-dot{width:7px;height:7px;flex:0 0 auto;border-radius:50%;background:#71818a}
+.network-dot.good{background:var(--good);box-shadow:0 0 0 3px #62c89918}.network-dot.bad{background:var(--bad);box-shadow:0 0 0 3px #ef706718}
+.network-value{display:block;margin-top:4px;font-size:14px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.network-detail{display:block;margin-top:2px;color:var(--dim);font-size:9px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.mwan-list{display:flex;gap:5px;flex-wrap:wrap;margin-top:13px}.mwan-chip{border:1px solid #42545e;border-radius:99px;padding:3px 7px;color:var(--dim);font-size:9px}.mwan-chip.online{border-color:#39725b;color:#9cdec0;background:#1e3b31}.mwan-chip.offline{border-color:#6a4542;color:#e6aaa5;background:#392624}.mwan-chip.paused{opacity:.58}
+.speed-row{display:flex;align-items:center;gap:12px;margin-top:13px;padding-top:12px;border-top:1px solid var(--line)}.speedtest-button{display:flex;align-items:center;justify-content:center;gap:7px;flex:0 0 auto;border:1px solid #42606e;border-radius:11px;background:#263b47;color:var(--ink);padding:9px 11px;font-size:11px;font-weight:730;cursor:pointer}
+.speedtest-button:active{transform:scale(.98)}.speedtest-button:disabled{opacity:.7;cursor:default}.speed-spinner{display:none;width:13px;height:13px;border:2px solid #87a8b8;border-top-color:var(--ink);border-radius:50%;animation:spin .8s linear infinite}.speedtest-button.running .speed-spinner{display:inline-block}.speedtest-button.running .speed-icon{display:none}
+.speed-results{min-width:0;color:var(--dim);font-size:11px}.speed-results strong{display:block;color:#dce8ed;font-size:12px;font-variant-numeric:tabular-nums}.speed-results.bad strong{color:#ffc1bc}@keyframes spin{to{transform:rotate(360deg)}}
 .speaker-backdrop{position:fixed;z-index:20;inset:0;background:#05090daa;display:flex;align-items:flex-end;opacity:0;pointer-events:none;transition:opacity .2s}
 .speaker-backdrop.open{opacity:1;pointer-events:auto}.speaker-sheet{width:min(100%,680px);max-height:min(78vh,680px);overflow:auto;margin:0 auto;
   background:#141e26;border:1px solid #38505e;border-bottom:0;border-radius:22px 22px 0 0;padding:8px 14px calc(18px + env(safe-area-inset-bottom));
@@ -763,7 +982,7 @@ h1{font-size:29px;line-height:1.05;letter-spacing:-.03em;margin:3px 0 0}.van-mar
 #toast{position:fixed;z-index:30;left:50%;top:calc(12px + env(safe-area-inset-top));transform:translate(-50%,-14px);width:min(calc(100% - 28px),620px);
   background:#22313d;color:var(--ink);border:1px solid #405967;border-radius:13px;padding:11px 14px;box-shadow:var(--shadow);opacity:0;pointer-events:none;transition:.2s;font-size:13px;text-align:center}
 #toast.show{opacity:1;transform:translate(-50%,0)}#toast.bad{border-color:#874944;color:#ffd8d4}body.busy [data-action]{pointer-events:none;opacity:.55}
-@media(max-width:420px){.grid{gap:9px}.tile{min-height:140px}.cop{min-height:205px}}@media(prefers-reduced-motion:reduce){*{transition:none!important}}
+@media(max-width:420px){.grid{gap:9px}.tile{min-height:140px}.cop{min-height:205px}.network-stat{padding-left:8px;padding-right:8px}.network-value{font-size:13px}.speed-row{gap:9px}}@media(prefers-reduced-motion:reduce){*{transition:none!important}.speed-spinner{animation:none}}
 </style></head><body>
 <header><div><div class="eyebrow">vanpi controls</div><h1>Van Dashboard</h1></div><div class="van-mark" aria-hidden="true">🚐</div></header>
 <main>
@@ -783,6 +1002,19 @@ h1{font-size:29px;line-height:1.05;letter-spacing:-.03em;margin:3px 0 0}.van-mar
       <span class="tile-icon" aria-hidden="true">🔊</span><span class="tile-title">Sonos</span><span class="tile-detail" id="speaker-summary">Finding speakers…</span>
     </button>
   </div>
+  <section class="connectivity" aria-labelledby="connectivity-title">
+    <div class="connectivity-head"><h2 id="connectivity-title">Connectivity</h2><span class="connectivity-age" id="connectivity-age">Checking…</span></div>
+    <div class="network-grid">
+      <div class="network-stat"><span class="network-label"><span class="network-dot" id="internet-dot"></span>Internet Connectivity</span><strong class="network-value" id="internet-status">Checking…</strong><span class="network-detail" id="mwan-primary">mwan3 mode · —</span></div>
+      <div class="network-stat"><span class="network-label"><span class="network-dot" id="ubnt-dot"></span>UBNT Availability</span><strong class="network-value" id="ubnt-status">Checking…</strong><span class="network-detail" id="ubnt-detail">Ethernet · —</span></div>
+      <div class="network-stat"><span class="network-label"><span class="network-dot" id="wireless-dot"></span>UBNT Wireless</span><strong class="network-value" id="wireless-status">Checking…</strong><span class="network-detail" id="wireless-detail">Association · —</span></div>
+    </div>
+    <div class="mwan-list" id="mwan-list" aria-label="mwan3 interfaces"></div>
+    <div class="speed-row">
+      <button class="speedtest-button" id="speedtest-button"><span class="speed-icon" aria-hidden="true">↕</span><span class="speed-spinner" aria-hidden="true"></span><span id="speedtest-label">Run speed test</span></button>
+      <div class="speed-results" id="speed-results" role="status" aria-live="polite"><strong>Not run yet</strong>Uses vanpi's current route</div>
+    </div>
+  </section>
 </main>
 <div class="speaker-backdrop" id="speaker-backdrop">
   <section class="speaker-sheet" id="speaker-panel" role="dialog" aria-modal="true" aria-labelledby="speaker-title">
@@ -793,7 +1025,7 @@ h1{font-size:29px;line-height:1.05;letter-spacing:-.03em;margin:3px 0 0}.van-mar
 </div>
 <div id="toast" role="status" aria-live="polite"></div>
 <script>
-const $=id=>document.getElementById(id);let dashboard=null,speakers=null,busy=false,toastTimer=0;
+const $=id=>document.getElementById(id);let dashboard=null,speakers=null,busy=false,toastTimer=0,speedPoll=0;
 function esc(v){return String(v??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
 function toast(message,bad=false){clearTimeout(toastTimer);const el=$('toast');el.textContent=message;el.className=bad?'show bad':'show';toastTimer=setTimeout(()=>el.className='',3400)}
 async function json(url,options){const response=await fetch(url,options);let data;try{data=await response.json()}catch(_){data={message:`Server returned ${response.status}`}}
@@ -802,6 +1034,28 @@ async function post(endpoint,params={}){return json('/api/'+endpoint,{method:'PO
 async function action(work){if(busy)return;busy=true;document.body.classList.add('busy');try{const result=await work();if(result?.message)toast(result.message);await refresh()}
   catch(error){toast(error.message,true)}finally{busy=false;document.body.classList.remove('busy')}}
 function age(ts){if(!ts)return 'never';const secs=Math.max(0,Date.now()/1000-ts);return secs<90?`${Math.round(secs)}s ago`:`${Math.round(secs/60)}m ago`}
+function networkState(id,value){const el=$(id);el.classList.remove('good','bad');if(value===true)el.classList.add('good');else if(value===false)el.classList.add('bad')}
+function renderConnectivity(response){const c=response.connectivity,r=c.router||{},u=c.ubnt||{},online=c.internet?.online;
+  networkState('internet-dot',online);$('internet-status').textContent=online===true?'Online':online===false?'Offline':'Unknown';
+  $('mwan-primary').textContent=r.reachable===false?'mwan3 · router unavailable':r.mode?`mwan3 mode · ${r.mode}`:r.reachable===true?'mwan3 · no active uplink':'mwan3 mode · —';
+  networkState('ubnt-dot',u.reachable);$('ubnt-status').textContent=u.reachable===true?'Reachable':u.reachable===false?'Unavailable':'Unknown';
+  $('ubnt-detail').textContent=u.reachable===false?'Ethernet cable or power':u.reachable===true?'Ethernet link responds':'Ethernet · —';
+  const radioKnown=u.reachable===true&&!u.error;networkState('wireless-dot',radioKnown?u.connected:u.reachable===false?false:null);
+  if(u.reachable===false){$('wireless-status').textContent='Unavailable';$('wireless-detail').textContent='No UBNT Ethernet response'}
+  else if(u.error){$('wireless-status').textContent='Status error';$('wireless-detail').textContent='Could not read radio'}
+  else if(u.reachable===true){$('wireless-status').textContent=u.ssid||'Unknown SSID';const details=[u.connected?'Connected':'Not associated'];if(u.connected&&Number.isFinite(u.signal_dbm))details.push(`${u.signal_dbm} dBm`);if(u.connected&&Number.isFinite(u.ccq_percent))details.push(`${u.ccq_percent}% CCQ`);else if(u.connected&&Number.isFinite(u.quality_percent))details.push(`${u.quality_percent}% quality`);$('wireless-detail').textContent=details.join(' · ')}
+  else{$('wireless-status').textContent='Unknown';$('wireless-detail').textContent='Association · —'}
+  $('mwan-list').innerHTML=(r.interfaces||[]).map(i=>`<span class="mwan-chip ${esc(i.state)} ${i.tracking==='paused'?'paused':''}" title="${esc(i.detail||'')}">${esc(i.name)} · ${esc(i.state)}${i.tracking==='paused'?' · paused':''}</span>`).join('');
+  $('connectivity-age').textContent=c.last_error?`Collector error · ${c.last_error}`:c.checked_at?`${c.stale?'Stale':'Updated'} · ${age(c.checked_at)}`:c.refreshing?'Checking…':'Waiting for collector'}
+async function refreshConnectivity(){try{renderConnectivity(await json('/api/connectivity'))}catch(error){$('connectivity-age').textContent=error.message}}
+function atTime(ts){return ts?'@ '+new Date(ts*1000).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',second:'2-digit',hour12:false}):''}
+function renderSpeedtest(response){const s=response.speedtest,button=$('speedtest-button'),running=s.status==='running';button.disabled=running;button.classList.toggle('running',running);button.setAttribute('aria-busy',String(running));$('speedtest-label').textContent=running?'Testing…':'Run speed test';$('speed-results').classList.toggle('bad',s.status==='error');
+  if(running)$('speed-results').innerHTML='<strong>Testing current route…</strong>This can take a minute';
+  else if(s.status==='complete')$('speed-results').innerHTML=`<strong>↓ ${Number(s.download_mbps).toFixed(1)} Mbps · ↑ ${Number(s.upload_mbps).toFixed(1)} Mbps</strong>Latency ${Number(s.latency_ms).toFixed(1)} ms ${atTime(s.completed_at)}`;
+  else if(s.status==='error')$('speed-results').innerHTML=`<strong>Speed test failed</strong>${esc(s.error||'Unknown error')} ${atTime(s.completed_at)}`;
+  else $('speed-results').innerHTML="<strong>Not run yet</strong>Uses vanpi's current route"}
+async function refreshSpeedtest(){clearTimeout(speedPoll);try{const response=await json('/api/speedtest');renderSpeedtest(response);if(response.speedtest.status==='running')speedPoll=setTimeout(refreshSpeedtest,1000)}catch(error){$('speed-results').innerHTML=`<strong>Speed test unavailable</strong>${esc(error.message)}`}}
+async function startSpeedtest(){if($('speedtest-button').disabled)return;$('speedtest-button').disabled=true;try{const response=await post('speedtest');renderSpeedtest(response);if(response.speedtest.status==='running')speedPoll=setTimeout(refreshSpeedtest,1000)}catch(error){toast(error.message,true);$('speedtest-button').disabled=false}}
 function updateStatus(data){dashboard=data.cop_alert;const active=dashboard.active,engine=dashboard.engine;$('dot').classList.add('on');$('connection').textContent='Connected · vanpi dashboard';
   $('cop').classList.toggle('active',active);$('cop').setAttribute('aria-pressed',String(active));$('cop-pill').textContent=active?'ACTIVE':'OFF';
   $('cop-detail').textContent=active?'Dashcam wake and 5-minute bacon alerts are active':'Tap to keep the dashcam awake';
@@ -820,12 +1074,13 @@ async function openSpeakers(){$('speaker-backdrop').classList.add('open');docume
 function closeSpeakers(){$('speaker-backdrop').classList.remove('open');document.body.classList.remove('sheet-open');$('speakers').setAttribute('aria-expanded','false');$('speakers').focus()}
 const bookUrl=new URL(window.location.href);bookUrl.port='8787';bookUrl.pathname='/';bookUrl.search='';bookUrl.hash='';$('books').href=bookUrl.toString();
 $('cop').addEventListener('click',()=>action(()=>post('cop-alert',{active:dashboard?.active?'false':'true'})));$('speakers').addEventListener('click',openSpeakers);$('speaker-close').addEventListener('click',closeSpeakers);
+$('speedtest-button').addEventListener('click',startSpeedtest);
 $('speaker-backdrop').addEventListener('click',event=>{if(event.target===$('speaker-backdrop'))closeSpeakers()});document.addEventListener('keydown',event=>{if(event.key==='Escape')closeSpeakers()});
 document.addEventListener('input',event=>{const slider=event.target.closest('[data-speaker-volume]');if(slider)slider.closest('.speaker-row').querySelector('.speaker-level').textContent=slider.value});
 document.addEventListener('change',event=>{const checkbox=event.target.closest('[data-group-speaker]');if(checkbox)action(async()=>{try{return await post('speakers/group',{name:checkbox.dataset.groupSpeaker,grouped:checkbox.checked?'1':'0'})}finally{await loadSpeakers()}});
   const slider=event.target.closest('[data-speaker-volume]');if(slider)action(async()=>{try{return await post('speakers/volume',{name:slider.dataset.speakerVolume,volume:slider.value})}finally{await loadSpeakers()}})});
 document.addEventListener('click',event=>{const selected=event.target.closest('[data-select-speaker]');if(selected)action(async()=>{const result=await post('speakers/select',{name:selected.dataset.selectSpeaker});await loadSpeakers();return result})});
-Promise.allSettled([refresh(),loadSpeakers()]).then(results=>{if(results[1].status==='rejected')$('speaker-summary').textContent='Sonos unavailable'});setInterval(()=>{if(!document.hidden)refresh()},5000);document.addEventListener('visibilitychange',()=>{if(!document.hidden)refresh()});
+Promise.allSettled([refresh(),loadSpeakers(),refreshConnectivity(),refreshSpeedtest()]).then(results=>{if(results[1].status==='rejected')$('speaker-summary').textContent='Sonos unavailable'});setInterval(()=>{if(!document.hidden)refresh()},5000);setInterval(()=>{if(!document.hidden)refreshConnectivity()},10000);document.addEventListener('visibilitychange',()=>{if(!document.hidden){refresh();refreshConnectivity();refreshSpeedtest()}});
 </script></body></html>"""
 
 
@@ -872,4 +1127,5 @@ def index():
 
 if __name__ == "__main__":
     cop_alert.start()
+    connectivity.start()
     app.run(host="0.0.0.0", port=PORT, threaded=True)

--- a/automation/van_dashboard.py
+++ b/automation/van_dashboard.py
@@ -50,14 +50,11 @@ SPEEDTEST = os.path.expanduser(
 CONNECTIVITY_INTERVAL = float(os.environ.get("VAN_DASHBOARD_CONNECTIVITY_INTERVAL", "30"))
 SPEEDTEST_TIMEOUT = float(os.environ.get("VAN_DASHBOARD_SPEEDTEST_TIMEOUT", "180"))
 TUYA_POLL_INTERVAL = float(os.environ.get("VAN_DASHBOARD_TUYA_POLL_INTERVAL", "15"))
-COP_LED_SOURCE = os.environ.get("VAN_DASHBOARD_COP_LED_SOURCE", "light.solder_led")
 COP_LED_TARGET = os.environ.get("VAN_DASHBOARD_COP_LED_TARGET", "light.ext_led")
-COP_LED_FALLBACK_BRIGHTNESS = int(
-    os.environ.get("VAN_DASHBOARD_COP_LED_FALLBACK_BRIGHTNESS", "170")
-)
-COP_LED_FALLBACK_KELVIN = int(
-    os.environ.get("VAN_DASHBOARD_COP_LED_FALLBACK_KELVIN", "2702")
-)
+# Captured from solder_led on 2026-07-18. COP ALERT deliberately uses this
+# fixed look; it does not query or depend on solder_led at activation time.
+COP_LED_BRIGHTNESS = 170
+COP_LED_COLOR_TEMP_KELVIN = 2702
 COP_LED_RETRY_INTERVAL = float(os.environ.get("VAN_DASHBOARD_COP_LED_RETRY_INTERVAL", "5"))
 COP_LED_VERIFY_INTERVAL = float(
     os.environ.get("VAN_DASHBOARD_COP_LED_VERIFY_INTERVAL", "30")
@@ -529,7 +526,6 @@ class CopLedManager:
         self,
         store,
         engine_monitor=None,
-        source=COP_LED_SOURCE,
         target=COP_LED_TARGET,
         command=run_command,
         clock=time.monotonic,
@@ -537,12 +533,11 @@ class CopLedManager:
         retry_interval=COP_LED_RETRY_INTERVAL,
         verify_interval=COP_LED_VERIFY_INTERVAL,
         connect_grace=COP_LED_CONNECT_GRACE,
-        fallback_brightness=COP_LED_FALLBACK_BRIGHTNESS,
-        fallback_kelvin=COP_LED_FALLBACK_KELVIN,
+        brightness=COP_LED_BRIGHTNESS,
+        color_temp_kelvin=COP_LED_COLOR_TEMP_KELVIN,
     ):
         self.store = store
         self.engine_monitor = engine_monitor
-        self.source = source
         self.target = target
         self.command = command
         self.clock = clock
@@ -550,9 +545,9 @@ class CopLedManager:
         self.retry_interval = retry_interval
         self.verify_interval = verify_interval
         self.connect_grace = connect_grace
-        self.fallback = {
-            "brightness": fallback_brightness,
-            "color_temp_kelvin": fallback_kelvin,
+        self.desired = {
+            "brightness": brightness,
+            "color_temp_kelvin": color_temp_kelvin,
         }
         self.lock = threading.Lock()
         self.stop_event = threading.Event()
@@ -561,8 +556,6 @@ class CopLedManager:
         self.was_active = False
         self.connect_started_at = None
         self.next_attempt = 0.0
-        self.desired = None
-        self.reference = None
         self.phase = "inactive"
         self.message = "COP ALERT is off"
         self.last_error = None
@@ -594,8 +587,6 @@ class CopLedManager:
                 "last_attempt": self.last_attempt,
                 "confirmed_at": self.confirmed_at,
                 "desired": copy.deepcopy(self.desired),
-                "reference": self.reference,
-                "source": self.source,
                 "target": self.target,
             }
 
@@ -607,8 +598,6 @@ class CopLedManager:
                 self.was_active = False
                 self.connect_started_at = None
                 self.next_attempt = 0.0
-                self.desired = None
-                self.reference = None
                 self.phase = "inactive"
                 self.message = "COP ALERT is off"
                 self.last_error = None
@@ -618,8 +607,6 @@ class CopLedManager:
                 self.was_active = True
                 self.connect_started_at = now
                 self.next_attempt = 0.0
-                self.desired = None
-                self.reference = None
                 self.phase = "preparing"
                 self.message = "Preparing ext_led"
                 self.last_error = None
@@ -645,18 +632,6 @@ class CopLedManager:
 
         with self.lock:
             desired = copy.deepcopy(self.desired)
-        if desired is None:
-            source_status, source_error = self._read_light(self.source)
-            desired = self._settings_from_status(source_status)
-            reference = self.source
-            if desired is None:
-                desired = dict(self.fallback)
-                reference = "captured solder_led fallback"
-            with self.lock:
-                self.desired = desired
-                self.reference = reference
-                if source_error:
-                    self.message = "Reference unavailable; using captured settings"
 
         target_status, target_error = self._read_light(self.target)
         if target_error or not target_status or target_status.get("state") == "unavailable":
@@ -717,8 +692,6 @@ class CopLedManager:
             "last_attempt": self.last_attempt,
             "confirmed_at": self.confirmed_at,
             "desired": copy.deepcopy(self.desired),
-            "reference": self.reference,
-            "source": self.source,
             "target": self.target,
         }
 
@@ -735,19 +708,6 @@ class CopLedManager:
         except (TypeError, ValueError):
             return None, f"could not read {entity}: invalid status response"
         return status if isinstance(status, dict) else None, None
-
-    @staticmethod
-    def _settings_from_status(status):
-        if not status:
-            return None
-        try:
-            brightness = int(status["brightness"])
-            kelvin = int(status["color_temp_kelvin"])
-        except (KeyError, TypeError, ValueError):
-            return None
-        if not 1 <= brightness <= 255 or not 2000 <= kelvin <= 7000:
-            return None
-        return {"brightness": brightness, "color_temp_kelvin": kelvin}
 
     @staticmethod
     def _matches(status, desired):

--- a/automation/van_dashboard.py
+++ b/automation/van_dashboard.py
@@ -942,22 +942,59 @@ class SonosController:
         coordinator = self.coordinator()
         coordinator_name = coordinator.player_name
         members = {member.player_name for member in coordinator.group.members}
+        try:
+            group_volume = coordinator.group.volume
+        except Exception:
+            group_volume = None
+        try:
+            group_muted = coordinator.group.mute
+        except Exception:
+            group_muted = None
+        try:
+            transport_state = coordinator.get_current_transport_info()[
+                "current_transport_state"
+            ]
+        except Exception:
+            transport_state = "UNKNOWN"
+        try:
+            track = coordinator.get_current_track_info() or {}
+        except Exception:
+            track = {}
+        now_playing = {
+            "title": track.get("title") or track.get("radio_show") or "Nothing playing",
+            "artist": track.get("artist") or track.get("album") or "",
+            "album": track.get("album") or "",
+            "position": track.get("position") or "",
+            "duration": track.get("duration") or "",
+            "transport_state": transport_state,
+        }
         speakers = []
         for name, zone in sorted(zones.items()):
             try:
                 volume = zone.volume
             except Exception:
                 volume = None
+            try:
+                muted = zone.mute
+            except Exception:
+                muted = None
             speakers.append(
                 {
                     "name": name,
                     "volume": volume,
+                    "muted": muted,
                     "grouped": name in members,
                     "coordinator": name == coordinator_name,
                     "group_coordinator": zone.group.coordinator.player_name,
                 }
             )
-        return {"ok": True, "coordinator": coordinator_name, "speakers": speakers}
+        return {
+            "ok": True,
+            "coordinator": coordinator_name,
+            "group": {"volume": group_volume, "muted": group_muted},
+            "now_playing": now_playing,
+            "speakers": speakers,
+        }
 
     def select(self, name):
         zones = self.get_zones()
@@ -995,6 +1032,41 @@ class SonosController:
         zones[name].volume = volume
         return volume
 
+    def set_mute(self, name, muted):
+        zones = self.get_zones()
+        if name not in zones:
+            raise KeyError(f"unknown speaker '{name}'")
+        zones[name].mute = bool(muted)
+        return bool(muted)
+
+    def set_group_volume(self, volume):
+        volume = max(0, min(100, int(volume)))
+        self.coordinator().group.volume = volume
+        return volume
+
+    def set_group_mute(self, muted):
+        muted = bool(muted)
+        self.coordinator().group.mute = muted
+        return muted
+
+    def transport(self, action):
+        if action not in ("play_pause", "previous", "next"):
+            raise ValueError("unknown Sonos transport action")
+        coordinator = self.coordinator()
+        if action == "play_pause":
+            state = coordinator.get_current_transport_info()["current_transport_state"]
+            if state == "PLAYING":
+                coordinator.pause()
+                return "Sonos paused"
+            coordinator.play()
+            return "Sonos playing"
+        if action == "previous":
+            coordinator.previous()
+            return "Previous Sonos track"
+        if action == "next":
+            coordinator.next()
+            return "Next Sonos track"
+
 
 class ConnectivityMonitor:
     """Cache the reusable connectivity collector away from HTTP request threads."""
@@ -1014,6 +1086,7 @@ class ConnectivityMonitor:
         self.wall_clock = wall_clock
         self.lock = threading.Lock()
         self.stop_event = threading.Event()
+        self.refresh_event = threading.Event()
         self.thread = None
         self.refreshing = False
         self.last_error = None
@@ -1049,6 +1122,11 @@ class ConnectivityMonitor:
 
     def stop(self):
         self.stop_event.set()
+        self.refresh_event.set()
+
+    def request_refresh(self):
+        """Wake the collector without doing router I/O in the request thread."""
+        self.refresh_event.set()
 
     def refresh(self):
         with self.lock:
@@ -1091,7 +1169,8 @@ class ConnectivityMonitor:
             started = self.clock()
             self.refresh()
             remaining = max(1.0, self.interval - (self.clock() - started))
-            self.stop_event.wait(remaining)
+            self.refresh_event.wait(remaining)
+            self.refresh_event.clear()
 
 
 def parse_speedtest_output(output):
@@ -1194,6 +1273,13 @@ def api_error(message, status):
     return jsonify({"ok": False, "message": str(message)}), status
 
 
+def request_boolean(name):
+    raw = request.values.get(name, "").strip().lower()
+    if raw not in ("1", "0", "true", "false", "on", "off"):
+        raise ValueError(f"{name} must be true or false")
+    return raw in ("1", "true", "on")
+
+
 @app.before_request
 def reject_cross_origin_mutations():
     """Block browser CSRF against vehicle-control POST endpoints.
@@ -1236,6 +1322,7 @@ def api_starlink():
         return api_error(exc, 503)
     except RuntimeError as exc:
         return api_error(exc, 502)
+    connectivity.request_refresh()
     return jsonify(
         {
             "ok": True,
@@ -1247,7 +1334,9 @@ def api_starlink():
 
 @app.route("/api/connectivity")
 def api_connectivity():
-    return jsonify({"ok": True, "connectivity": connectivity.snapshot()})
+    response = jsonify({"ok": True, "connectivity": connectivity.snapshot()})
+    response.headers["Cache-Control"] = "no-store"
+    return response
 
 
 @app.route("/api/speedtest", methods=["GET", "POST"])
@@ -1324,6 +1413,60 @@ def api_speaker_volume():
     return jsonify({"ok": True, "message": f"{name} volume: {volume}", "volume": volume})
 
 
+@app.route("/api/speakers/mute", methods=["POST"])
+def api_speaker_mute():
+    name = request.values.get("name", "").strip()
+    try:
+        muted = request_boolean("muted")
+        muted = sonos.set_mute(name, muted)
+    except ValueError as exc:
+        return api_error(exc, 400)
+    except KeyError as exc:
+        return api_error(exc.args[0], 404)
+    except Exception as exc:
+        return api_error(f"could not mute {name}: {exc}", 502)
+    verb = "muted" if muted else "unmuted"
+    return jsonify({"ok": True, "message": f"{name} {verb}", "muted": muted})
+
+
+@app.route("/api/speakers/group-volume", methods=["POST"])
+def api_speaker_group_volume():
+    try:
+        volume = int(request.values.get("volume", ""))
+    except (TypeError, ValueError):
+        return api_error("volume must be from 0 to 100", 400)
+    try:
+        volume = sonos.set_group_volume(volume)
+    except Exception as exc:
+        return api_error(f"could not set Sonos group volume: {exc}", 502)
+    return jsonify({"ok": True, "message": f"Group volume: {volume}", "volume": volume})
+
+
+@app.route("/api/speakers/group-mute", methods=["POST"])
+def api_speaker_group_mute():
+    try:
+        muted = request_boolean("muted")
+        muted = sonos.set_group_mute(muted)
+    except ValueError as exc:
+        return api_error(exc, 400)
+    except Exception as exc:
+        return api_error(f"could not mute Sonos group: {exc}", 502)
+    verb = "muted" if muted else "unmuted"
+    return jsonify({"ok": True, "message": f"Sonos group {verb}", "muted": muted})
+
+
+@app.route("/api/speakers/transport", methods=["POST"])
+def api_speaker_transport():
+    action = request.values.get("action", "").strip().lower()
+    try:
+        message = sonos.transport(action)
+    except ValueError as exc:
+        return api_error(exc, 400)
+    except Exception as exc:
+        return api_error(f"Sonos transport failed: {exc}", 502)
+    return jsonify({"ok": True, "message": message})
+
+
 PAGE = r"""<!doctype html>
 <html lang="en"><head>
 <meta charset="utf-8">
@@ -1367,6 +1510,8 @@ h1{font-size:29px;line-height:1.05;letter-spacing:-.03em;margin:3px 0 0}.van-mar
 .starlink{min-height:210px;transition:border-color .2s,background .2s,opacity .2s}.starlink .tile-icon{font-size:38px}.starlink .tile-title{font-size:23px}.starlink.on{border-color:#438168;background:radial-gradient(circle at 88% 5%,#62c89928,transparent 38%),linear-gradient(145deg,#1d2b2b,#172225)}
 .starlink.off{border-color:#754743;background:radial-gradient(circle at 88% 5%,#ef70671c,transparent 38%),linear-gradient(145deg,#292124,#1b2025)}.starlink.unknown{border-color:#41505a;background:linear-gradient(145deg,#202a32,#182128)}.starlink:disabled{cursor:not-allowed;opacity:.72}
 .switch-state{position:absolute;right:14px;top:14px;display:flex;align-items:center;gap:7px;border:1px solid var(--line);border-radius:99px;padding:4px 8px;background:#10171dcc;color:var(--dim);font-size:10px;font-weight:800;letter-spacing:.08em}.starlink.on .switch-state{color:#bcebd5;border-color:#39725b}.starlink.off .switch-state{color:#f2b5b0;border-color:#754743}
+.sonos-tile{cursor:default;min-height:174px}.sonos-tile:active{transform:none;background:linear-gradient(145deg,var(--panel),#151f28)}.sonos-head{width:100%;display:flex;align-items:center;justify-content:space-between;gap:8px}.sonos-open{min-width:0;max-width:68%;display:flex;align-items:center;gap:5px;border:1px solid var(--line);border-radius:9px;background:#1e2b34;color:var(--dim);padding:5px 8px;font-size:10px;cursor:pointer}.sonos-open span:last-child{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.now-playing{width:100%;min-width:0;margin-top:13px}.now-playing strong,.now-playing span{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.now-playing strong{font-size:15px;color:var(--ink)}.now-playing span{font-size:11px;color:var(--dim);margin-top:2px}.transport{display:flex;align-items:center;justify-content:space-between;width:100%;margin-top:auto;padding-top:12px}.transport-button{width:46px;height:36px;border:0;border-radius:10px;background:transparent;color:#dce8ed;font-size:22px;line-height:1;cursor:pointer}.transport-button:active{background:#ffffff12;transform:scale(.95)}.transport-button.play{font-size:28px}
 .connectivity{margin-top:11px;border:1px solid var(--line);border-radius:19px;background:linear-gradient(145deg,var(--panel),#151f28);padding:15px;box-shadow:0 8px 28px #050b102e}
 .connectivity-head{display:flex;align-items:baseline;justify-content:space-between;gap:12px;margin-bottom:13px}.connectivity-head h2{font-size:17px;margin:0;letter-spacing:-.01em}
 .connectivity-age{color:var(--dim);font-size:10px;text-align:right}.network-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:0}
@@ -1384,10 +1529,11 @@ h1{font-size:29px;line-height:1.05;letter-spacing:-.03em;margin:3px 0 0}.van-mar
   box-shadow:0 -18px 60px #000a;transform:translateY(24px);transition:transform .2s}.speaker-backdrop.open .speaker-sheet{transform:translateY(0)}
 .sheet-grabber{width:38px;height:4px;border-radius:3px;background:#4d626e;margin:2px auto 12px}.sheet-head{display:flex;align-items:center;justify-content:space-between;gap:12px}
 .sheet-head h2{margin:0;font-size:18px;letter-spacing:-.01em}.sheet-close{border:1px solid var(--line);background:var(--raised);color:var(--ink);border-radius:50%;width:38px;height:38px;font-size:20px}
-.sheet-help{color:var(--dim);font-size:12px;margin:3px 0 14px}.speaker-row{display:grid;grid-template-columns:30px minmax(0,1fr) 35px;align-items:center;column-gap:8px;padding:11px 8px;border-top:1px solid var(--line)}
+.sheet-help{color:var(--dim);font-size:12px;margin:3px 0 14px}.group-audio{display:grid;grid-template-columns:42px minmax(0,1fr) 35px;align-items:center;column-gap:10px;padding:12px 8px 15px}.group-audio-label{grid-column:1/4;color:var(--ink);font-size:12px;font-weight:700;margin-bottom:6px}.audio-mute{width:38px;height:38px;border:0;border-radius:10px;background:transparent;color:var(--ink);font-size:22px;line-height:1;cursor:pointer}.audio-mute:active{background:#ffffff12}.audio-mute.muted{color:var(--bad)}.group-volume,.speaker-volume{width:100%;accent-color:var(--accent)}.group-level{font-size:11px;color:var(--dim);text-align:right;font-variant-numeric:tabular-nums}
+.speaker-row{display:grid;grid-template-columns:30px 42px minmax(0,1fr) 35px;align-items:center;column-gap:8px;padding:11px 8px;border-top:1px solid var(--line)}
 .speaker-check{width:22px;height:22px;margin:0;accent-color:var(--accent)}.speaker-name{border:0;background:transparent;color:var(--ink);padding:2px 0;text-align:left;font-weight:700;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .speaker-name small{display:block;color:var(--dim);font-size:10px;font-weight:500;margin-top:1px}.speaker-level{font-size:11px;color:var(--dim);text-align:right;font-variant-numeric:tabular-nums}
-.speaker-volume{grid-column:2/4;width:100%;margin:8px 0 0;accent-color:var(--accent)}.speaker-loading{padding:28px;text-align:center;color:var(--dim)}body.sheet-open{overflow:hidden}
+.speaker-volume{grid-column:3/5;margin:8px 0 0}.speaker-loading{padding:28px;text-align:center;color:var(--dim)}body.sheet-open{overflow:hidden}
 #toast{position:fixed;z-index:30;left:50%;top:calc(12px + env(safe-area-inset-top));transform:translate(-50%,-14px);width:min(calc(100% - 28px),620px);
   background:#22313d;color:var(--ink);border:1px solid #405967;border-radius:13px;padding:11px 14px;box-shadow:var(--shadow);opacity:0;pointer-events:none;transition:.2s;font-size:13px;text-align:center}
 #toast.show{opacity:1;transform:translate(-50%,0)}#toast.bad{border-color:#874944;color:#ffd8d4}body.busy [data-action]{pointer-events:none;opacity:.55}
@@ -1413,9 +1559,15 @@ h1{font-size:29px;line-height:1.05;letter-spacing:-.03em;margin:3px 0 0}.van-mar
       <span class="tile-detail" id="starlink-detail">Checking Tuya status…</span>
     </button>
     <a class="tile" id="books" data-action href="#"><span class="tile-icon" aria-hidden="true">📖</span><span class="tile-title">Audiobooks</span><span class="tile-detail">Open the Sonos audiobook library</span></a>
-    <button class="tile" id="speakers" data-action aria-haspopup="dialog" aria-expanded="false" aria-controls="speaker-panel">
-      <span class="tile-icon" aria-hidden="true">🔊</span><span class="tile-title">Sonos</span><span class="tile-detail" id="speaker-summary">Finding speakers…</span>
-    </button>
+    <section class="tile sonos-tile" aria-labelledby="sonos-title">
+      <div class="sonos-head"><span class="tile-title" id="sonos-title">Sonos</span><button class="sonos-open" id="speakers" data-action aria-haspopup="dialog" aria-expanded="false" aria-controls="speaker-panel"><span aria-hidden="true">🔊</span><span id="speaker-summary">Finding…</span></button></div>
+      <div class="now-playing"><strong id="sonos-track">Finding Sonos…</strong><span id="sonos-artist">—</span></div>
+      <div class="transport" aria-label="Sonos playback controls">
+        <button class="transport-button" data-action data-transport="previous" aria-label="Previous track">|◀</button>
+        <button class="transport-button play" id="sonos-play" data-action data-transport="play_pause" aria-label="Play">▶</button>
+        <button class="transport-button" data-action data-transport="next" aria-label="Next track">▶|</button>
+      </div>
+    </section>
   </div>
   <section class="connectivity" aria-labelledby="connectivity-title">
     <div class="connectivity-head"><h2 id="connectivity-title">Connectivity</h2><span class="connectivity-age" id="connectivity-age">Checking…</span></div>
@@ -1435,6 +1587,12 @@ h1{font-size:29px;line-height:1.05;letter-spacing:-.03em;margin:3px 0 0}.van-mar
   <section class="speaker-sheet" id="speaker-panel" role="dialog" aria-modal="true" aria-labelledby="speaker-title">
     <div class="sheet-grabber"></div><div class="sheet-head"><h2 id="speaker-title">Sonos speakers</h2><button class="sheet-close" id="speaker-close" aria-label="Close speaker selector">×</button></div>
     <p class="sheet-help">Tap a name to control its group. Check speakers to group them with the active player.</p>
+    <div class="group-audio">
+      <div class="group-audio-label">Group volume</div>
+      <button class="audio-mute" id="group-mute" data-action data-group-mute disabled aria-label="Mute group">🔊</button>
+      <input class="group-volume" id="group-volume" data-action data-group-volume type="range" min="0" max="100" value="0" disabled aria-label="Group volume">
+      <span class="group-level" id="group-level">—</span>
+    </div>
     <div id="speaker-list"><div class="speaker-loading">Finding speakers…</div></div>
   </section>
 </div>
@@ -1443,7 +1601,7 @@ h1{font-size:29px;line-height:1.05;letter-spacing:-.03em;margin:3px 0 0}.van-mar
 const $=id=>document.getElementById(id);let dashboard=null,speakers=null,busy=false,toastTimer=0,speedPoll=0;
 function esc(v){return String(v??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
 function toast(message,bad=false){clearTimeout(toastTimer);const el=$('toast');el.textContent=message;el.className=bad?'show bad':'show';toastTimer=setTimeout(()=>el.className='',3400)}
-async function json(url,options){const response=await fetch(url,options);let data;try{data=await response.json()}catch(_){data={message:`Server returned ${response.status}`}}
+async function json(url,options){const response=await fetch(url,{cache:'no-store',...(options||{})});let data;try{data=await response.json()}catch(_){data={message:`Server returned ${response.status}`}}
   if(!response.ok||data.ok===false)throw new Error(data.message||`Request failed (${response.status})`);return data}
 async function post(endpoint,params={}){return json('/api/'+endpoint,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded','X-Van-Dashboard':'1'},body:new URLSearchParams(params)})}
 async function action(work){if(busy)return;busy=true;document.body.classList.add('busy');try{const result=await work();if(result?.message)toast(result.message);await refresh()}
@@ -1477,24 +1635,29 @@ function updateStatus(data){dashboard=data.cop_alert;const active=dashboard.acti
   $('flood').textContent=dashboard.ext_flood;$('cop-led').textContent=led.message||'No data';$('cop-led').title=led.last_error||'';$('wake').textContent=dashboard.last_wake_ok===null?'Not attempted':dashboard.last_wake_ok?`OK · ${age(dashboard.last_wake)}`:'DEGRADED';
   if(active&&dashboard.last_error)$('connection').textContent=`Active with warning · ${dashboard.last_error}`}
 async function refresh(){try{updateStatus(await json('/api/status'))}catch(error){$('dot').classList.remove('on');$('dot').classList.add('bad');$('connection').textContent=error.message}}
-function renderSpeakers(next){speakers=next;const grouped=next.speakers.filter(s=>s.grouped);$('speaker-summary').textContent=`${next.coordinator} · ${grouped.length}/${next.speakers.length} grouped`;
-  $('speaker-list').innerHTML=next.speakers.map(s=>{const detail=s.coordinator?'Active coordinator':s.grouped?`Grouped with ${next.coordinator}`:`Group: ${s.group_coordinator}`;
-    const volume=Number.isFinite(s.volume)?s.volume:0;return `<div class="speaker-row"><input class="speaker-check" data-action data-group-speaker="${esc(s.name)}" type="checkbox" ${s.grouped?'checked':''} ${s.coordinator?'disabled':''} aria-label="Group ${esc(s.name)}">
+function muteIcon(muted){return muted?'🔇':'🔊'}
+function renderSpeakers(next){speakers=next;const grouped=next.speakers.filter(s=>s.grouped),now=next.now_playing||{},group=next.group||{};$('speaker-summary').textContent=`${next.coordinator} · ${grouped.length}/${next.speakers.length}`;$('sonos-track').textContent=now.title||'Nothing playing';$('sonos-artist').textContent=now.artist||next.coordinator;
+  const playing=now.transport_state==='PLAYING';$('sonos-play').textContent=playing?'Ⅱ':'▶';$('sonos-play').setAttribute('aria-label',playing?'Pause':'Play');
+  const groupVolume=Number.isFinite(group.volume)?group.volume:0;$('group-volume').value=groupVolume;$('group-volume').disabled=!Number.isFinite(group.volume);$('group-level').textContent=Number.isFinite(group.volume)?group.volume:'—';const groupMuteKnown=typeof group.muted==='boolean';$('group-mute').disabled=!groupMuteKnown;$('group-mute').textContent=muteIcon(group.muted);$('group-mute').classList.toggle('muted',group.muted===true);$('group-mute').setAttribute('aria-pressed',String(group.muted===true));$('group-mute').setAttribute('aria-label',group.muted?'Unmute group':'Mute group');
+  $('speaker-list').innerHTML=next.speakers.map(s=>{const detail=s.coordinator?'Active coordinator':s.grouped?`Grouped with ${next.coordinator}`:`Group: ${s.group_coordinator}`,volume=Number.isFinite(s.volume)?s.volume:0,muteKnown=typeof s.muted==='boolean';return `<div class="speaker-row"><input class="speaker-check" data-action data-group-speaker="${esc(s.name)}" type="checkbox" ${s.grouped?'checked':''} ${s.coordinator?'disabled':''} aria-label="Group ${esc(s.name)}">
+      <button class="audio-mute ${s.muted?'muted':''}" data-action data-speaker-mute="${esc(s.name)}" ${muteKnown?'':'disabled'} aria-pressed="${String(s.muted===true)}" aria-label="${s.muted?'Unmute':'Mute'} ${esc(s.name)}">${muteIcon(s.muted)}</button>
       <button class="speaker-name" data-action data-select-speaker="${esc(s.name)}">${esc(s.name)}<small>${esc(detail)}</small></button><span class="speaker-level">${Number.isFinite(s.volume)?s.volume:'—'}</span>
       <input class="speaker-volume" data-action data-speaker-volume="${esc(s.name)}" type="range" min="0" max="100" value="${volume}" ${Number.isFinite(s.volume)?'':'disabled'} aria-label="${esc(s.name)} volume"></div>`}).join('')||'<div class="speaker-loading">No Sonos speakers found</div>'}
 async function loadSpeakers(){const next=await json('/api/speakers');renderSpeakers(next);return next}
+async function refreshSonos(){try{return await loadSpeakers()}catch(error){$('speaker-summary').textContent='Unavailable';$('sonos-track').textContent='Sonos unavailable';$('sonos-artist').textContent=error.message}}
 async function openSpeakers(){$('speaker-backdrop').classList.add('open');document.body.classList.add('sheet-open');$('speakers').setAttribute('aria-expanded','true');
   try{await loadSpeakers()}catch(error){$('speaker-list').innerHTML=`<div class="speaker-loading">${esc(error.message)}</div>`;toast(error.message,true)}}
 function closeSpeakers(){$('speaker-backdrop').classList.remove('open');document.body.classList.remove('sheet-open');$('speakers').setAttribute('aria-expanded','false');$('speakers').focus()}
 const bookUrl=new URL(window.location.href);bookUrl.port='8787';bookUrl.pathname='/';bookUrl.search='';bookUrl.hash='';$('books').href=bookUrl.toString();
-$('cop').addEventListener('click',()=>action(()=>post('cop-alert',{active:dashboard?.active?'false':'true'})));$('starlink').addEventListener('click',()=>{renderStarlink({state:'unknown',changing:true});action(()=>post('starlink'))});$('speakers').addEventListener('click',openSpeakers);$('speaker-close').addEventListener('click',closeSpeakers);
+$('cop').addEventListener('click',()=>action(()=>post('cop-alert',{active:dashboard?.active?'false':'true'})));$('starlink').addEventListener('click',()=>{renderStarlink({state:'unknown',changing:true});action(async()=>{const result=await post('starlink');await refreshConnectivity();return result})});$('speakers').addEventListener('click',openSpeakers);$('speaker-close').addEventListener('click',closeSpeakers);
 $('speedtest-button').addEventListener('click',startSpeedtest);
 $('speaker-backdrop').addEventListener('click',event=>{if(event.target===$('speaker-backdrop'))closeSpeakers()});document.addEventListener('keydown',event=>{if(event.key==='Escape')closeSpeakers()});
-document.addEventListener('input',event=>{const slider=event.target.closest('[data-speaker-volume]');if(slider)slider.closest('.speaker-row').querySelector('.speaker-level').textContent=slider.value});
+document.addEventListener('input',event=>{const slider=event.target.closest('[data-speaker-volume]');if(slider)slider.closest('.speaker-row').querySelector('.speaker-level').textContent=slider.value;const groupSlider=event.target.closest('[data-group-volume]');if(groupSlider)$('group-level').textContent=groupSlider.value});
 document.addEventListener('change',event=>{const checkbox=event.target.closest('[data-group-speaker]');if(checkbox)action(async()=>{try{return await post('speakers/group',{name:checkbox.dataset.groupSpeaker,grouped:checkbox.checked?'1':'0'})}finally{await loadSpeakers()}});
-  const slider=event.target.closest('[data-speaker-volume]');if(slider)action(async()=>{try{return await post('speakers/volume',{name:slider.dataset.speakerVolume,volume:slider.value})}finally{await loadSpeakers()}})});
-document.addEventListener('click',event=>{const selected=event.target.closest('[data-select-speaker]');if(selected)action(async()=>{const result=await post('speakers/select',{name:selected.dataset.selectSpeaker});await loadSpeakers();return result})});
-Promise.allSettled([refresh(),loadSpeakers(),refreshConnectivity(),refreshSpeedtest()]).then(results=>{if(results[1].status==='rejected')$('speaker-summary').textContent='Sonos unavailable'});setInterval(()=>{if(!document.hidden)refresh()},5000);setInterval(()=>{if(!document.hidden)refreshConnectivity()},10000);document.addEventListener('visibilitychange',()=>{if(!document.hidden){refresh();refreshConnectivity();refreshSpeedtest()}});
+  const slider=event.target.closest('[data-speaker-volume]');if(slider)action(async()=>{try{return await post('speakers/volume',{name:slider.dataset.speakerVolume,volume:slider.value})}finally{await loadSpeakers()}});const groupSlider=event.target.closest('[data-group-volume]');if(groupSlider)action(async()=>{try{return await post('speakers/group-volume',{volume:groupSlider.value})}finally{await loadSpeakers()}})});
+document.addEventListener('click',event=>{const selected=event.target.closest('[data-select-speaker]');if(selected)action(async()=>{const result=await post('speakers/select',{name:selected.dataset.selectSpeaker});await loadSpeakers();return result});const transport=event.target.closest('[data-transport]');if(transport)action(async()=>{try{return await post('speakers/transport',{action:transport.dataset.transport})}finally{await loadSpeakers()}});const groupMute=event.target.closest('[data-group-mute]');if(groupMute)action(async()=>{try{return await post('speakers/group-mute',{muted:speakers?.group?.muted?'0':'1'})}finally{await loadSpeakers()}});const speakerMute=event.target.closest('[data-speaker-mute]');if(speakerMute)action(async()=>{const item=speakers?.speakers?.find(s=>s.name===speakerMute.dataset.speakerMute);try{return await post('speakers/mute',{name:speakerMute.dataset.speakerMute,muted:item?.muted?'0':'1'})}finally{await loadSpeakers()}})});
+function refreshVisibleDashboard(){if(document.hidden)return;refresh();refreshConnectivity();refreshSpeedtest();refreshSonos()}
+Promise.allSettled([refresh(),loadSpeakers(),refreshConnectivity(),refreshSpeedtest()]).then(results=>{if(results[1].status==='rejected')refreshSonos()});setInterval(()=>{if(!document.hidden)refresh()},5000);setInterval(()=>{if(!document.hidden)refreshConnectivity()},10000);setInterval(()=>{if(!document.hidden&&!busy)refreshSonos()},10000);document.addEventListener('visibilitychange',refreshVisibleDashboard);window.addEventListener('pageshow',refreshVisibleDashboard);window.addEventListener('focus',refreshVisibleDashboard);
 </script></body></html>"""
 
 

--- a/pi/COP_ALERT.md
+++ b/pi/COP_ALERT.md
@@ -1,0 +1,83 @@
+# Van Dashboard and COP ALERT
+
+`van-dashboard.service` serves the dashboard on port `8788` (all interfaces),
+so the same URL works through the LAN hostname or a Tailscale hostname/address:
+
+```text
+http://vanpi.lan:8788/
+```
+
+The Audiobooks tile preserves the current host and changes only the port to
+`8787`, so it also works over Tailscale.
+
+The service has no user-login layer; it is intended only for the trusted van
+LAN and Tailscale ACL. Do not forward port `8788` from a public interface. The
+server rejects cross-origin browser control requests to reduce CSRF risk.
+
+## COP ALERT behavior
+
+While active, the dashboard:
+
+- persists the active state in `/home/pi/.van_dashboard_state.json`;
+- keeps Home Assistant entity `switch.ext_flood` on while the engine is stopped;
+- sends an RF Hub `22 F190` identification read every 15 seconds on C-CAN. This
+  is the already-verified parked C-CAN wake that powers the dash accessory rail;
+- sends `🥓 COP ALERT is active` through `ntfy_send.sh` immediately and every
+  five minutes, which resolves `NTFY_MESSAGE_URL` from the existing secrets;
+- passively reads C-CAN engine speed and publishes short-lived marker files in
+  `/run/van-dashboard` for the ignition hook.
+
+Turning COP ALERT off stops CAN wake and ntfy messages and turns `ext_flood`
+off. If the service restarts while the persisted state is active, it resumes
+the alert behavior.
+
+The dashboard never changes `can0` bitrate, listen-only mode, or link state.
+The C-CAN wake therefore requires the shared interface to already be UP,
+armed, and at 500 kbit/s. A mismatch is shown as a degraded CAN wake rather
+than reconfiguring the interface out from under another CAN service.
+
+## Engine-running gate
+
+The gate requires two standard C-CAN engine-speed broadcasts, each using bytes
+0-1 big-endian: `0x0F4` divided by 8 and `0x0FC` divided by 4. In the labeled
+captures inspected on 2026-07-17:
+
+- ignition on, engine stopped: `0x0F4` was `0` in all 2,000 samples and `0x0FC`
+  was `0` in all 1,999 samples;
+- engine running: `0x0F4` was `0x1780`, or 752 RPM, in all 6,000 samples;
+  `0x0FC` varied from 721-773 RPM with a 752 RPM median across 5,999 samples.
+
+`0x0FC`'s natural idle variation supports using it as the actual-speed
+evidence; requiring the matching `0x0F4` broadcast as well prevents either
+field alone from releasing `ext_flood`.
+
+The dashboard requires five consecutive plausible samples from 300-8,000 RPM
+and treats the evidence as stale after 2.5 seconds. `ignition_on.sh` reads the
+persisted COP ALERT state and may turn `ext_flood` off during COP ALERT only
+while that fresh engine marker exists. Missing, stale, or ambiguous CAN data
+preserves the switch, including across a dashboard restart. When the engine
+stops, COP ALERT resumes `ext_flood` and parked CAN wakes.
+
+## B-CAN follow-up
+
+COP ALERT intentionally supports only the currently connected C-CAN path.
+Before supporting a PCAN moved to B-CAN:
+
+1. Wire in the existing verified B-CAN wake primitive from
+   `/home/pi/dev/obd-things/lib/canbus.py`: 75 benign `0x7FF` DLC-0 frames at
+   20 ms spacing on the verified 125 kbit/s bus, followed by passive restore.
+2. Resolve shared-interface ownership so the dashboard cannot race another
+   service by changing bitrate or listen-only state.
+3. Derive and validate a true engine-running/RPM field from the labeled B-CAN
+   `ignition_on.log` and `engine_on.log` captures. Do not substitute bus
+   activity, ignition state, or charging voltage for actual engine-running
+   evidence.
+4. Add capture-backed tests equivalent to the dual C-CAN RPM gate before B-CAN
+   is allowed to release `ext_flood`.
+
+## Dependencies
+
+The system Python used by the service needs `flask`, `soco`, and `can-isotp`.
+The existing `tuya_toggle.sh`, `tuya_status.sh`, and `ntfy_send.sh` scripts and
+their existing secret files remain the only Home Assistant/ntfy integrations;
+the dashboard contains no credentials.

--- a/pi/COP_ALERT.md
+++ b/pi/COP_ALERT.md
@@ -62,8 +62,8 @@ While active, the dashboard:
 
 - persists the active state in `/home/pi/.van_dashboard_state.json`;
 - keeps Home Assistant entity `switch.ext_flood` on while the engine is stopped;
-- asynchronously configures `light.ext_led` to match the current brightness and
-  color temperature of `light.solder_led`, then reads it back for confirmation;
+- asynchronously configures `light.ext_led` to fixed brightness `170/255` and
+  `2702 K`, then reads it back for confirmation;
 - sends an RF Hub `22 F190` identification read every 15 seconds on C-CAN. This
   is the already-verified parked C-CAN wake that powers the dash accessory rail;
 - sends `🥓 COP ALERT is active` through `ntfy_send.sh` immediately and every
@@ -91,14 +91,11 @@ during a 90-second connection grace period, then `ext_led unavailable · still
 retrying` if RF remains blocked. Neither state disables the alert, CAN wake,
 `ext_flood`, or ntfy behavior.
 
-At the start of each activation the worker reads `light.solder_led`, the light
-powered by `switch.solder_flood`. The settings captured on 2026-07-18 were
-brightness `170/255` (67%) and `2702 K` in color-temperature mode. Those values
-are the fallback if the reference light cannot be read, and can be overridden
-with `VAN_DASHBOARD_COP_LED_FALLBACK_BRIGHTNESS` and
-`VAN_DASHBOARD_COP_LED_FALLBACK_KELVIN`. The worker pauses while verified engine
-RPM causes COP ALERT to intentionally turn `ext_flood` off, then resumes when
-the engine stops.
+The fixed look—brightness `170/255` (67%) and `2702 K` in color-temperature
+mode—was captured from `light.solder_led` on 2026-07-18. The worker never reads
+or depends on `solder_led` during COP ALERT. It pauses while verified engine RPM
+causes COP ALERT to intentionally turn `ext_flood` off, then resumes when the
+engine stops.
 
 ## Engine-running gate
 

--- a/pi/COP_ALERT.md
+++ b/pi/COP_ALERT.md
@@ -43,6 +43,19 @@ immediately, while `GET /api/speedtest` reports progress and the eventual
 download, upload, latency, and completion time. The browser renders completion
 as `@ HH:MM:SS` in its local time. The test is never run automatically.
 
+## Starlink power
+
+The Starlink tile reads `switch.starlink` through the existing Tuya/Home
+Assistant helpers every 15 seconds. Confirmed on is green, confirmed off is
+red, and unavailable/unread status is neutral grey. The tile is disabled while
+status is unknown so it never guesses a toggle direction. After a power change,
+the dashboard reads the authoritative switch state again; failed verification
+returns the tile to grey.
+
+The same neutral/failed/live color convention applies to dashboard status
+icons: grey means no data yet, red means confirmed down or failed, and green
+means confirmed active or reachable.
+
 ## COP ALERT behavior
 
 While active, the dashboard:

--- a/pi/COP_ALERT.md
+++ b/pi/COP_ALERT.md
@@ -18,7 +18,7 @@ server rejects cross-origin browser control requests to reduce CSRF risk.
 
 The Connectivity card keeps three related states separate:
 
-- Internet Connectivity comes from mwan3's existing reachability tracking;
+- MWAN3 comes from mwan3's existing reachability tracking;
 - UBNT Availability is a single ping that detects lost Ethernet/power; and
 - UBNT Wireless requires a real access-point association. A configured SSID
   is still shown when the radio says `Not-Associated`, but it is not reported
@@ -62,6 +62,8 @@ While active, the dashboard:
 
 - persists the active state in `/home/pi/.van_dashboard_state.json`;
 - keeps Home Assistant entity `switch.ext_flood` on while the engine is stopped;
+- asynchronously configures `light.ext_led` to match the current brightness and
+  color temperature of `light.solder_led`, then reads it back for confirmation;
 - sends an RF Hub `22 F190` identification read every 15 seconds on C-CAN. This
   is the already-verified parked C-CAN wake that powers the dash accessory rail;
 - sends `🥓 COP ALERT is active` through `ntfy_send.sh` immediately and every
@@ -77,6 +79,26 @@ The dashboard never changes `can0` bitrate, listen-only mode, or link state.
 The C-CAN wake therefore requires the shared interface to already be UP,
 armed, and at 500 kbit/s. A mismatch is shown as a degraded CAN wake rather
 than reconfiguring the interface out from under another CAN service.
+
+## Exterior LED matching
+
+The COP ALERT request is not blocked by the exterior light. A separate worker
+waits for `light.ext_led` to join Wi-Fi after `ext_flood` supplies power, then
+uses `tuya_light.sh` to apply and read back the desired light settings. It
+retries every five seconds while the target is unavailable and re-verifies a
+confirmed light every 30 seconds. The tile shows `Waiting for ext_led Wi-Fi`
+during a 90-second connection grace period, then `ext_led unavailable · still
+retrying` if RF remains blocked. Neither state disables the alert, CAN wake,
+`ext_flood`, or ntfy behavior.
+
+At the start of each activation the worker reads `light.solder_led`, the light
+powered by `switch.solder_flood`. The settings captured on 2026-07-18 were
+brightness `170/255` (67%) and `2702 K` in color-temperature mode. Those values
+are the fallback if the reference light cannot be read, and can be overridden
+with `VAN_DASHBOARD_COP_LED_FALLBACK_BRIGHTNESS` and
+`VAN_DASHBOARD_COP_LED_FALLBACK_KELVIN`. The worker pauses while verified engine
+RPM causes COP ALERT to intentionally turn `ext_flood` off, then resumes when
+the engine stops.
 
 ## Engine-running gate
 
@@ -122,6 +144,6 @@ Before supporting a PCAN moved to B-CAN:
 The system Python used by the service needs `flask`, `soco`, and `can-isotp`.
 The existing speed-test script needs `speedtest-cli`; the connectivity
 collector adds no Python packages or router-side software.
-The existing `tuya_toggle.sh`, `tuya_status.sh`, and `ntfy_send.sh` scripts and
-their existing secret files remain the only Home Assistant/ntfy integrations;
-the dashboard contains no credentials.
+The existing `tuya_toggle.sh`, `tuya_status.sh`, and `ntfy_send.sh` scripts plus
+the new `tuya_light.sh` helper use the existing secret files for Home
+Assistant/ntfy integrations; the dashboard contains no credentials.

--- a/pi/COP_ALERT.md
+++ b/pi/COP_ALERT.md
@@ -37,6 +37,11 @@ thread every 30 seconds and serves cached results through
 path, and command paths can be overridden with the collector's
 `CONNECTIVITY_*` environment variables.
 
+The page reads that cache every 10 seconds with browser caching disabled. It
+also reads immediately when a suspended tab becomes visible or focused, and a
+Starlink power change wakes the background collector without running router or
+UBNT commands in the HTTP request thread.
+
 The speed-test button starts `/home/pi/scripts/speedtest.sh` in a separate
 thread. Only one test can run at a time; `POST /api/speedtest` returns
 immediately, while `GET /api/speedtest` reports progress and the eventual
@@ -55,6 +60,13 @@ returns the tile to grey.
 The same neutral/failed/live color convention applies to dashboard status
 icons: grey means no data yet, red means confirmed down or failed, and green
 means confirmed active or reachable.
+
+## Sonos controls
+
+The Sonos tile follows the selected group's coordinator and shows the current
+track, artist, and play/pause/previous/next controls. Its speaker sheet keeps
+the existing group-selection checkboxes and adds native Sonos group volume,
+whole-group mute, individual volume, and individual mute controls.
 
 ## COP ALERT behavior
 

--- a/pi/COP_ALERT.md
+++ b/pi/COP_ALERT.md
@@ -14,6 +14,35 @@ The service has no user-login layer; it is intended only for the trusted van
 LAN and Tailscale ACL. Do not forward port `8788` from a public interface. The
 server rejects cross-origin browser control requests to reduce CSRF risk.
 
+## Connectivity and speed tests
+
+The Connectivity card keeps three related states separate:
+
+- Internet Connectivity comes from mwan3's existing reachability tracking;
+- UBNT Availability is a single ping that detects lost Ethernet/power; and
+- UBNT Wireless requires a real access-point association. A configured SSID
+  is still shown when the radio says `Not-Associated`, but it is not reported
+  as connected. When associated, signal, link quality/CCQ, and bitrate are
+  available to the dashboard.
+
+The mwan3 mode lists every online uplink (for example `clientwan + wan`) so a
+balanced multi-uplink state is not mislabeled as a single primary route.
+
+`/home/pi/scripts/connectivity_status.py` is a reusable, standard-library JSON
+collector. It performs one read-only `mwan3 interfaces` SSH query per run, one
+UBNT ping, and (only when the UBNT responds) one read-only radio-status SSH
+query. It never scans for networks. The dashboard runs it in a background
+thread every 30 seconds and serves cached results through
+`GET /api/connectivity`, so browser polling adds no router load. Hosts, key
+path, and command paths can be overridden with the collector's
+`CONNECTIVITY_*` environment variables.
+
+The speed-test button starts `/home/pi/scripts/speedtest.sh` in a separate
+thread. Only one test can run at a time; `POST /api/speedtest` returns
+immediately, while `GET /api/speedtest` reports progress and the eventual
+download, upload, latency, and completion time. The browser renders completion
+as `@ HH:MM:SS` in its local time. The test is never run automatically.
+
 ## COP ALERT behavior
 
 While active, the dashboard:
@@ -78,6 +107,8 @@ Before supporting a PCAN moved to B-CAN:
 ## Dependencies
 
 The system Python used by the service needs `flask`, `soco`, and `can-isotp`.
+The existing speed-test script needs `speedtest-cli`; the connectivity
+collector adds no Python packages or router-side software.
 The existing `tuya_toggle.sh`, `tuya_status.sh`, and `ntfy_send.sh` scripts and
 their existing secret files remain the only Home Assistant/ntfy integrations;
 the dashboard contains no credentials.

--- a/pi/hooks/ignition_on.sh
+++ b/pi/hooks/ignition_on.sh
@@ -2,6 +2,7 @@
 isw="$HOME/scripts/internet_switches.sh"
 tuya_toggle="$HOME/scripts/tuya_toggle.sh"
 tuya_device_ids="$HOME/scripts/tuya_device_ids.sh"
+cop_alert_ext_flood_guard="$HOME/scripts/cop_alert_ext_flood_guard.sh"
 inactive="$HOME/hooks/inactive/ignition"
 mconf="$HOME/mconf"
 log="$HOME/log/ignition_monitor.log"
@@ -15,7 +16,11 @@ stop_disks() {
 
 
 turn_lights_off() {
-  $tuya_toggle ext_flood off & # switches
+  if "$cop_alert_ext_flood_guard" >> "$log" 2>&1; then
+    "$tuya_toggle" ext_flood off & # safe: inactive, stale, or engine confirmed running via C-CAN
+  else
+    echo "COP ALERT preserved ext_flood (no fresh C-CAN engine-running evidence)" >> "$log"
+  fi
   $tuya_toggle solder_flood off & # switches
   # $tuya_toggle cab_wiz off &
   $tuya_device_ids | grep "^light." | while read -r line; do

--- a/pi/scripts/connectivity_status.py
+++ b/pi/scripts/connectivity_status.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Report van network uplink and UBNT radio state as JSON.
+
+This collector is intentionally passive and cheap: it reuses mwan3's existing
+reachability tracking, pings the UBNT once to distinguish an unplugged cable,
+and reads the UBNT's current association data without running a wireless scan.
+"""
+
+import json
+import os
+import re
+import subprocess
+import time
+
+
+ROUTER_TARGET = os.environ.get("CONNECTIVITY_ROUTER_TARGET", "root@OpenWrt")
+UBNT_TARGET = os.environ.get("CONNECTIVITY_UBNT_TARGET", "ubnt@192.168.8.20")
+UBNT_HOST = os.environ.get("CONNECTIVITY_UBNT_HOST", UBNT_TARGET.rsplit("@", 1)[-1])
+UBNT_IDENTITY = os.path.expanduser(
+    os.environ.get("CONNECTIVITY_UBNT_IDENTITY", "~/.ssh/id_rsa")
+)
+SSH = os.environ.get("CONNECTIVITY_SSH", "/usr/bin/ssh")
+PING = os.environ.get("CONNECTIVITY_PING", "/usr/bin/ping")
+
+MWAN_PRIORITY = ("clientwan", "lifiwan", "wan")
+
+
+def run_command(args, timeout=8):
+    return subprocess.run(args, capture_output=True, text=True, timeout=timeout, check=False)
+
+
+def parse_mwan3_interfaces(output):
+    """Parse ``mwan3 interfaces`` without depending on OpenWrt JSON helpers."""
+    interfaces = []
+    pattern = re.compile(
+        r"^\s*interface\s+(?P<name>\S+)\s+is\s+"
+        r"(?P<state>online|offline|disabled|unknown)(?P<detail>.*)$",
+        re.IGNORECASE,
+    )
+    for line in output.splitlines():
+        match = pattern.match(line)
+        if not match:
+            continue
+        detail = match.group("detail").strip(" ,")
+        interfaces.append(
+            {
+                "name": match.group("name"),
+                "state": match.group("state").lower(),
+                "tracking": "paused" if "tracking is paused" in detail.lower() else "active",
+                "detail": detail or None,
+            }
+        )
+    return interfaces
+
+
+def select_mode(interfaces):
+    online = {item["name"] for item in interfaces if item["state"] == "online"}
+    ordered = []
+    for name in MWAN_PRIORITY:
+        if name in online:
+            ordered.append(name)
+    ordered.extend(
+        item["name"]
+        for item in interfaces
+        if item["state"] == "online" and item["name"] not in ordered
+    )
+    return " + ".join(ordered) or None
+
+
+def _number(pattern, output, cast=int):
+    match = re.search(pattern, output, re.IGNORECASE | re.MULTILINE)
+    if not match:
+        return None
+    try:
+        return cast(match.group(1))
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_ubnt_wireless(output):
+    """Separate the configured ESSID from actual AP association state."""
+    # AirOS can expose a profile label (for example STARLINK) as ESSID while
+    # wpa_supplicant targets the real access-point SSID (for example denlink).
+    essid_match = re.search(r"^target_ssid=(.*)$", output, re.IGNORECASE | re.MULTILINE)
+    if not essid_match:
+        essid_match = re.search(r'ESSID:"([^"]*)"', output, re.IGNORECASE)
+    if not essid_match:
+        essid_match = re.search(r"^essid=(.*)$", output, re.IGNORECASE | re.MULTILINE)
+    ssid = essid_match.group(1).strip() if essid_match else None
+    if ssid in ("", "off/any"):
+        ssid = None
+
+    ap_match = re.search(r"Access Point:\s*(\S+)", output, re.IGNORECASE)
+    access_point = ap_match.group(1).strip() if ap_match else None
+    disconnected_aps = {None, "not-associated", "00:00:00:00:00:00"}
+    connected = access_point.lower() not in disconnected_aps if access_point else False
+
+    quality_match = re.search(r"Link Quality[=:]\s*(\d+)\s*/\s*(\d+)", output, re.IGNORECASE)
+    quality_percent = None
+    if quality_match and int(quality_match.group(2)):
+        quality_percent = round(100 * int(quality_match.group(1)) / int(quality_match.group(2)))
+
+    bitrate_match = re.search(
+        r"Bit Rate[=:]\s*([0-9.]+)\s*([^\s]+(?:/s)?)", output, re.IGNORECASE
+    )
+    bitrate = None
+    if bitrate_match:
+        bitrate = f"{bitrate_match.group(1)} {bitrate_match.group(2)}"
+
+    return {
+        "connected": connected,
+        "ssid": ssid,
+        "access_point": access_point,
+        "signal_dbm": _number(r"Signal level[=:]\s*(-?\d+)", output),
+        "noise_dbm": _number(r"Noise level[=:]\s*(-?\d+)", output),
+        "quality_percent": quality_percent,
+        "ccq_percent": _number(r"^ccq=(-?\d+)", output),
+        "bitrate": bitrate,
+        "frequency_ghz": _number(r"Frequency[=:]\s*([0-9.]+)\s*GHz", output, float),
+    }
+
+
+def _ssh_args(target, identity=None):
+    args = [
+        SSH,
+        "-n",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=4",
+    ]
+    if identity:
+        args.extend(("-i", identity))
+    args.append(target)
+    return args
+
+
+def _failure_detail(result):
+    detail = (result.stderr or result.stdout or "command failed").strip()
+    return detail[-300:] if detail else "command failed"
+
+
+def collect_status(command=run_command, wall_clock=time.time):
+    checked_at = int(wall_clock())
+    router = {
+        "reachable": False,
+        "mode": None,
+        "online": [],
+        "interfaces": [],
+        "error": None,
+    }
+    internet_online = None
+
+    try:
+        result = command(
+            _ssh_args(ROUTER_TARGET) + ["/usr/sbin/mwan3 interfaces"], timeout=8
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        router["error"] = str(exc)
+    else:
+        if result.returncode == 0:
+            router["reachable"] = True
+            router["interfaces"] = parse_mwan3_interfaces(result.stdout)
+            router["online"] = [
+                item["name"] for item in router["interfaces"] if item["state"] == "online"
+            ]
+            router["mode"] = select_mode(router["interfaces"])
+            if router["interfaces"]:
+                internet_online = bool(router["online"])
+            else:
+                router["error"] = "mwan3 returned no interface state"
+        else:
+            router["error"] = _failure_detail(result)
+
+    ubnt = {
+        "reachable": False,
+        "connected": False,
+        "ssid": None,
+        "access_point": None,
+        "signal_dbm": None,
+        "noise_dbm": None,
+        "quality_percent": None,
+        "ccq_percent": None,
+        "bitrate": None,
+        "frequency_ghz": None,
+        "error": None,
+    }
+    try:
+        ping = command([PING, "-c", "1", "-W", "2", UBNT_HOST], timeout=4)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        ubnt["error"] = str(exc)
+    else:
+        ubnt["reachable"] = ping.returncode == 0
+        if not ubnt["reachable"]:
+            ubnt["error"] = "UBNT did not answer ping (check Ethernet cable/power)"
+
+    if ubnt["reachable"]:
+        remote_status = (
+            "/sbin/iwconfig ath0 2>&1; "
+            "/usr/bin/mca-status 2>/dev/null | "
+            "/bin/grep -E '^(essid|signal|noise|ccq|uptime)=' || true; "
+            "/usr/bin/awk -F= '/^wpasupplicant\\.profile\\.1\\.network\\.1\\.ssid=/"
+            "{print \"target_ssid=\" $2; exit}' /tmp/system.cfg"
+        )
+        try:
+            result = command(
+                _ssh_args(UBNT_TARGET, UBNT_IDENTITY) + [remote_status], timeout=8
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            ubnt["error"] = f"UBNT status failed: {exc}"
+        else:
+            if result.returncode == 0:
+                ubnt.update(parse_ubnt_wireless(result.stdout))
+                ubnt["error"] = None
+            else:
+                ubnt["error"] = f"UBNT status failed: {_failure_detail(result)}"
+
+    return {
+        "checked_at": checked_at,
+        "internet": {
+            "online": internet_online,
+            "source": "mwan3 reachability tracking",
+        },
+        "router": router,
+        "ubnt": ubnt,
+    }
+
+
+def main():
+    print(json.dumps(collect_status(), separators=(",", ":"), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/pi/scripts/cop_alert_ext_flood_guard.sh
+++ b/pi/scripts/cop_alert_ext_flood_guard.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Exit 0 when ignition_on.sh may turn ext_flood off; exit 1 when a persisted
+# active COP ALERT must retain control.  The engine marker is created only
+# from fresh passive C-CAN RPM evidence by van_dashboard.py.
+set -u
+
+runtime_dir="${VAN_DASHBOARD_RUNTIME_DIR:-/run/van-dashboard}"
+state_path="${VAN_DASHBOARD_STATE_PATH:-/home/pi/.van_dashboard_state.json}"
+active_marker="$runtime_dir/cop-alert.active"
+engine_marker="$runtime_dir/engine-running"
+engine_max_age=3
+
+fresh_regular_file() {
+  local path="$1"
+  local max_age="$2"
+  local modified now age
+
+  [[ -f "$path" && ! -L "$path" ]] || return 1
+  modified=$(/usr/bin/stat -c %Y -- "$path") || return 1
+  now=$(/usr/bin/date +%s) || return 1
+  age=$((now - modified))
+  (( age >= 0 && age <= max_age ))
+}
+
+cop_alert_active() {
+  # Persistent state is authoritative across service restarts. The runtime
+  # marker is a fail-safe for the brief interval around an atomic state update
+  # or an unreadable state file.
+  if [[ -f "$state_path" && ! -L "$state_path" ]]; then
+    if /usr/bin/jq -e '.cop_alert == true' "$state_path" >/dev/null 2>&1; then
+      return 0
+    fi
+    if /usr/bin/jq -e '.cop_alert == false' "$state_path" >/dev/null 2>&1; then
+      return 1
+    fi
+  fi
+  [[ -f "$active_marker" && ! -L "$active_marker" ]]
+}
+
+if ! cop_alert_active; then
+  echo "COP ALERT inactive: ignition may turn ext_flood off"
+  exit 0
+fi
+
+if fresh_regular_file "$engine_marker" "$engine_max_age"; then
+  echo "fresh C-CAN engine-running evidence: ignition may turn ext_flood off"
+  exit 0
+fi
+
+echo "COP ALERT active without fresh engine-running evidence: preserving ext_flood"
+exit 1

--- a/pi/scripts/tuya_light.sh
+++ b/pi/scripts/tuya_light.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+action=${1:-}
+entity=${2:-}
+ha_url=${TUYA_HA_URL:-http://vanpi.local:8123}
+token_file=${TUYA_TOKEN_FILE:-/home/pi/secrets/localtuya_token}
+
+if [[ "$action" != "status" && "$action" != "set" ]]; then
+  echo "usage: tuya_light.sh <status|set> <light.entity> [brightness color_temp_kelvin]" >&2
+  exit 2
+fi
+if [[ ! "$entity" =~ ^light\.[a-z0-9_]+$ ]]; then
+  echo "expected a light entity, got '$entity'" >&2
+  exit 2
+fi
+
+token=$(/usr/bin/cat -- "$token_file")
+
+if [[ "$action" == "status" ]]; then
+  response=$(/usr/bin/curl -fsS --max-time 15 \
+    -H "Authorization: Bearer $token" \
+    -H "Content-Type: application/json" \
+    "$ha_url/api/states/$entity") || {
+      echo "failed to read $entity" >&2
+      exit 1
+    }
+  printf '%s' "$response" | /usr/bin/jq -ce '{
+    state,
+    color_mode: .attributes.color_mode,
+    brightness: .attributes.brightness,
+    color_temp_kelvin: .attributes.color_temp_kelvin
+  }'
+  exit
+fi
+
+brightness=${3:-}
+color_temp_kelvin=${4:-}
+if [[ ! "$brightness" =~ ^[0-9]+$ ]] || (( brightness < 1 || brightness > 255 )); then
+  echo "brightness must be from 1 to 255" >&2
+  exit 2
+fi
+if [[ ! "$color_temp_kelvin" =~ ^[0-9]+$ ]] || \
+   (( color_temp_kelvin < 2000 || color_temp_kelvin > 7000 )); then
+  echo "color_temp_kelvin must be from 2000 to 7000" >&2
+  exit 2
+fi
+
+payload=$(/usr/bin/jq -cn \
+  --arg entity_id "$entity" \
+  --argjson brightness "$brightness" \
+  --argjson color_temp_kelvin "$color_temp_kelvin" \
+  '{entity_id: $entity_id, brightness: $brightness, color_temp_kelvin: $color_temp_kelvin}')
+
+if ! /usr/bin/curl -fsS --max-time 15 -X POST \
+    -H "Authorization: Bearer $token" \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "$ha_url/api/services/light/turn_on" >/dev/null; then
+  echo "failed to set $entity" >&2
+  exit 1
+fi
+
+printf '{"brightness":%s,"color_temp_kelvin":%s}\n' "$brightness" "$color_temp_kelvin"

--- a/pi/scripts/tuya_status.sh
+++ b/pi/scripts/tuya_status.sh
@@ -1,21 +1,31 @@
-#! /bin/bash
+#!/bin/bash
 
-name=$1 # starlink, cab_wiz, ext_flood, solder_flood
+name=${1:-} # starlink, cab_wiz, ext_flood, solder_flood
 token=$(cat /home/pi/secrets/localtuya_token)
+
+if [[ -z "$name" ]]; then
+  echo "usage: tuya_status.sh <entity name>" >&2
+  exit 1
+fi
 
 # assumes no duplicate names, otherwise provide full device_type_name ie switch.cab_wiz
 if [[ "$name" == *.* ]]; then
   type_name=$name
 else
-  type_name=$(/home/pi/scripts/tuya_device_ids.sh | grep -P "\w+\.$name")
-  num_devices=$(echo $type_name | wc -l)
+  type_name=$(/home/pi/scripts/tuya_device_ids.sh | grep -P "\w+\.$name" || true)
+  num_devices=$(printf '%s\n' "$type_name" | grep -c .)
   if [ $num_devices -ne 1 ]; then
-    echo "multiple matching devices - aborting status check:\n$type_name"
-    return 1
+    printf 'expected one matching device, found %s:\n%s\n' "$num_devices" "$type_name" >&2
+    exit 1
   fi
 fi
 
-curl -s -X GET \
+if ! response=$(/usr/bin/curl -fsS --max-time 15 -X GET \
   -H "Authorization: Bearer $token" \
   -H "Content-Type: application/json" \
-  http://vanpi.local:8123/api/states/$type_name | jq -r .state
+  "http://vanpi.local:8123/api/states/$type_name"); then
+  echo "failed to read $type_name" >&2
+  exit 1
+fi
+
+printf '%s' "$response" | /usr/bin/jq -er '.state'

--- a/pi/scripts/tuya_toggle.sh
+++ b/pi/scripts/tuya_toggle.sh
@@ -1,8 +1,8 @@
-#! /bin/bash
+#!/bin/bash
 # tuya_toggle.sh aux on
 log="$HOME/log/tuya_toggle.log"
-entity=$1 # starlink, cab_wiz, ext_flood, solder_flood, light.dresser, starlink
-to_state=$2 # on, off, blank means toggle
+entity=${1:-} # starlink, cab_wiz, ext_flood, solder_flood, light.dresser, starlink
+to_state=${2:-} # on, off, blank means toggle
 token=$(cat /home/pi/secrets/localtuya_token)
 
 write_log() {
@@ -18,6 +18,11 @@ if [[ -z "$entity" ]]; then
   if return 2>/dev/null; then return 1; else exit 1; fi
 fi
 
+if [[ -n "$to_state" && "$to_state" != "on" && "$to_state" != "off" ]]; then
+  write_log "invalid state '$to_state' (expected on or off)"
+  if return 2>/dev/null; then return 1; else exit 1; fi
+fi
+
 if [[ "$entity" == *.* ]]; then
   type_name=$entity
 else
@@ -27,16 +32,22 @@ fi
 IFS='.' read -r type name <<< "$type_name"
 
 if [[ -z "$to_state" ]]; then
-  state=$(/home/pi/scripts/tuya_status.sh $name)
+  if ! state=$(/home/pi/scripts/tuya_status.sh "$name"); then
+    write_log "could not read $type_name; refusing to guess toggle direction"
+    if return 2>/dev/null; then return 1; else exit 1; fi
+  fi
   [[ "$state" == "on" ]] && to_state=off || to_state=on
 fi
 
 write_log "turning type name: $type_name, type: $type, to_state: $to_state"
 
-curl -s POST \
+if ! /usr/bin/curl -fsS --max-time 15 -X POST \
   -H "Authorization: Bearer $token" \
   -H "Content-Type: application/json" \
   -d "{\"entity_id\": \"$type_name\"}" \
-  http://vanpi.local:8123/api/services/$type/turn_$to_state > /dev/null
+  "http://vanpi.local:8123/api/services/$type/turn_$to_state" > /dev/null; then
+  write_log "failed to turn $type_name $to_state"
+  if return 2>/dev/null; then return 1; else exit 1; fi
+fi
 
-echo $to_state
+echo "$to_state"

--- a/pi/services/van-dashboard.service
+++ b/pi/services/van-dashboard.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Van Dashboard web UI (COP ALERT + Sonos controls on :8788)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/bin/python3 /home/pi/scripts/python-automation/van_dashboard.py
+WorkingDirectory=/home/pi
+Restart=always
+RestartSec=5
+User=pi
+Environment=PYTHONUNBUFFERED=1
+RuntimeDirectory=van-dashboard
+RuntimeDirectoryMode=0750
+UMask=0027
+
+[Install]
+WantedBy=multi-user.target

--- a/pi/services/van-dashboard.service
+++ b/pi/services/van-dashboard.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Van Dashboard web UI (COP ALERT + Sonos controls on :8788)
+Description=Van Dashboard web UI (COP ALERT, Sonos, connectivity on :8788)
 After=network-online.target
 Wants=network-online.target
 

--- a/pi/services/van-dashboard.service
+++ b/pi/services/van-dashboard.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Van Dashboard web UI (COP ALERT, Sonos, connectivity on :8788)
+Description=Van Dashboard web UI (COP ALERT, Tuya, Sonos, connectivity on :8788)
 After=network-online.target
 Wants=network-online.target
 

--- a/tests/test_connectivity_status.py
+++ b/tests/test_connectivity_status.py
@@ -1,0 +1,87 @@
+import unittest
+from types import SimpleNamespace
+
+from pi.scripts import connectivity_status as connectivity
+
+
+MWAN_SAMPLE = """Interface status:
+ interface wan is offline 00h:00m:00s, uptime 94h:02m:31s and tracking is active
+ interface clientwan is online 00h:35m:11s, uptime 21h:16m:11s and tracking is active
+ interface lifiwan is offline and tracking is paused
+"""
+
+DISCONNECTED_UBNT = """ath0 IEEE 802.11ng ESSID:"STARLINK"
+ Mode:Managed Frequency:2.424 GHz Access Point: Not-Associated
+ Bit Rate:0 kb/s
+ Link Quality=0/94 Signal level=-96 dBm Noise level=-96 dBm
+ccq=0
+target_ssid=denlink
+"""
+
+CONNECTED_UBNT = """ath0 IEEE 802.11ng ESSID:"profile-label"
+ Mode:Managed Frequency:2.437 GHz Access Point: 00:11:22:33:44:55
+ Bit Rate=65 Mb/s
+ Link Quality=70/94 Signal level=-61 dBm Noise level=-96 dBm
+ccq=88
+target_ssid=real-network
+"""
+
+
+class ConnectivityParserTests(unittest.TestCase):
+    def test_mwan_parser_and_priority(self):
+        interfaces = connectivity.parse_mwan3_interfaces(MWAN_SAMPLE)
+        self.assertEqual([item["name"] for item in interfaces], ["wan", "clientwan", "lifiwan"])
+        self.assertEqual(connectivity.select_mode(interfaces), "clientwan")
+        self.assertEqual(interfaces[2]["tracking"], "paused")
+
+    def test_configured_ssid_does_not_imply_association(self):
+        status = connectivity.parse_ubnt_wireless(DISCONNECTED_UBNT)
+        self.assertEqual(status["ssid"], "denlink")
+        self.assertFalse(status["connected"])
+        self.assertEqual(status["ccq_percent"], 0)
+
+    def test_connected_radio_metrics(self):
+        status = connectivity.parse_ubnt_wireless(CONNECTED_UBNT)
+        self.assertTrue(status["connected"])
+        self.assertEqual(status["ssid"], "real-network")
+        self.assertEqual(status["signal_dbm"], -61)
+        self.assertEqual(status["noise_dbm"], -96)
+        self.assertEqual(status["quality_percent"], 74)
+        self.assertEqual(status["ccq_percent"], 88)
+        self.assertEqual(status["bitrate"], "65 Mb/s")
+
+    def test_collector_reuses_mwan_state_and_passively_reads_ubnt(self):
+        calls = []
+
+        def command(args, timeout):
+            calls.append(tuple(args))
+            if args[-1] == "/usr/sbin/mwan3 interfaces":
+                return SimpleNamespace(returncode=0, stdout=MWAN_SAMPLE, stderr="")
+            if args[0] == connectivity.PING:
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            return SimpleNamespace(returncode=0, stdout=DISCONNECTED_UBNT, stderr="")
+
+        status = connectivity.collect_status(command=command, wall_clock=lambda: 1_700_000_000)
+        self.assertTrue(status["internet"]["online"])
+        self.assertEqual(status["router"]["mode"], "clientwan")
+        self.assertTrue(status["ubnt"]["reachable"])
+        self.assertFalse(status["ubnt"]["connected"])
+        self.assertEqual(len(calls), 3)
+        self.assertFalse(any("scan" in " ".join(call).lower() for call in calls))
+
+    def test_unreachable_ubnt_skips_radio_ssh(self):
+        calls = []
+
+        def command(args, timeout):
+            calls.append(tuple(args))
+            if args[0] == connectivity.PING:
+                return SimpleNamespace(returncode=1, stdout="", stderr="")
+            return SimpleNamespace(returncode=0, stdout=MWAN_SAMPLE, stderr="")
+
+        status = connectivity.collect_status(command=command)
+        self.assertFalse(status["ubnt"]["reachable"])
+        self.assertEqual(len(calls), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_van_dashboard.py
+++ b/tests/test_van_dashboard.py
@@ -192,6 +192,43 @@ class ConnectivityMonitorTests(unittest.TestCase):
         self.assertFalse(status["stale"])
 
 
+class TuyaSwitchManagerTests(unittest.TestCase):
+    def test_reads_and_toggles_confirmed_starlink_state(self):
+        state = "on"
+        calls = []
+
+        def command(args, timeout):
+            nonlocal state
+            calls.append(tuple(args))
+            if args[0] == dashboard.TUYA_STATUS:
+                return SimpleNamespace(returncode=0, stdout=state + "\n", stderr="")
+            if args[0] == dashboard.TUYA_TOGGLE:
+                state = args[2]
+                return SimpleNamespace(returncode=0, stdout=state + "\n", stderr="")
+            raise AssertionError(args)
+
+        switch = dashboard.TuyaSwitchManager(
+            "starlink", command=command, wall_clock=lambda: 1_700_000_000
+        )
+        self.assertEqual(switch.refresh()["state"], "on")
+        toggled = switch.toggle()
+        self.assertEqual(toggled["state"], "off")
+        self.assertTrue(toggled["available"])
+        self.assertEqual(calls[1], (dashboard.TUYA_TOGGLE, "starlink", "off"))
+        self.assertEqual(calls[2], (dashboard.TUYA_STATUS, "starlink"))
+
+    def test_failed_status_is_neutral_and_cannot_guess_toggle_direction(self):
+        def command(args, timeout):
+            return SimpleNamespace(returncode=1, stdout="unavailable\n", stderr="")
+
+        switch = dashboard.TuyaSwitchManager("starlink", command=command)
+        status = switch.refresh()
+        self.assertEqual(status["state"], "unknown")
+        self.assertFalse(status["available"])
+        with self.assertRaises(ValueError):
+            switch.toggle()
+
+
 class SpeedTestManagerTests(unittest.TestCase):
     def test_parser_accepts_existing_speedtest_script_output(self):
         output = "Download Speed: 42.75 Mbps\nUpload Speed:   8.5 Mbps\nLatency:        37.2 ms\n"
@@ -312,8 +349,10 @@ class DashboardRouteTests(unittest.TestCase):
         page = client.get("/")
         self.assertEqual(page.status_code, 200)
         self.assertIn(b"COP ALERT", page.data)
-        self.assertIn(b"Internet Connectivity", page.data)
-        self.assertIn(b"mwan3 mode", page.data)
+        self.assertIn(b"Starlink", page.data)
+        self.assertIn(b"MWAN3", page.data)
+        self.assertNotIn(b">Internet Connectivity<", page.data)
+        self.assertNotIn(b">Reachable<", page.data)
         self.assertIn(b"Run speed test", page.data)
         self.assertIn(b"bookUrl.port='8787'", page.data)
         manifest = client.get("/manifest.webmanifest")

--- a/tests/test_van_dashboard.py
+++ b/tests/test_van_dashboard.py
@@ -282,13 +282,6 @@ class CopLedManagerTests(unittest.TestCase):
 
         def command(args, timeout):
             self.calls.append(tuple(args))
-            if args[1:3] == ["status", "light.solder_led"]:
-                status = {
-                    "state": "on",
-                    "brightness": 170,
-                    "color_temp_kelvin": 2702,
-                }
-                return SimpleNamespace(returncode=0, stdout=json.dumps(status), stderr="")
             if args[1:3] == ["status", "light.ext_led"]:
                 return SimpleNamespace(returncode=0, stdout=json.dumps(self.target), stderr="")
             if args[1:3] == ["set", "light.ext_led"]:
@@ -313,7 +306,7 @@ class CopLedManagerTests(unittest.TestCase):
     def tearDown(self):
         self.tempdir.cleanup()
 
-    def test_waits_for_wifi_then_applies_and_confirms_reference_settings(self):
+    def test_waits_for_wifi_then_applies_and_confirms_fixed_settings(self):
         self.store.set("cop_alert", True)
         waiting = self.manager.tick()
         self.assertEqual(waiting["phase"], "waiting")
@@ -351,29 +344,6 @@ class CopLedManagerTests(unittest.TestCase):
         status = self.manager.tick()
         self.assertEqual(status["phase"], "inactive")
         self.assertEqual(self.calls, [])
-
-    def test_uses_captured_settings_when_reference_cannot_be_read(self):
-        def command(args, timeout):
-            if args[1:3] == ["status", "light.solder_led"]:
-                return SimpleNamespace(returncode=1, stdout="", stderr="reference offline")
-            status = {"state": "unavailable", "brightness": None, "color_temp_kelvin": None}
-            return SimpleNamespace(returncode=0, stdout=json.dumps(status), stderr="")
-
-        manager = dashboard.CopLedManager(
-            self.store,
-            self.engine,
-            command=command,
-            clock=self.clock,
-            fallback_brightness=170,
-            fallback_kelvin=2702,
-        )
-        self.store.set("cop_alert", True)
-        status = manager.tick()
-        self.assertEqual(
-            status["desired"], {"brightness": 170, "color_temp_kelvin": 2702}
-        )
-        self.assertEqual(status["reference"], "captured solder_led fallback")
-
 
 class CopAlertManagerTests(unittest.TestCase):
     def setUp(self):

--- a/tests/test_van_dashboard.py
+++ b/tests/test_van_dashboard.py
@@ -267,6 +267,114 @@ class SpeedTestManagerTests(unittest.TestCase):
         self.assertEqual(status["completed_at"], 1234)
 
 
+class CopLedManagerTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.store = dashboard.StateStore(os.path.join(self.tempdir.name, "state.json"))
+        self.clock = FakeClock()
+        self.engine = FakeEngine()
+        self.target = {
+            "state": "unavailable",
+            "brightness": None,
+            "color_temp_kelvin": None,
+        }
+        self.calls = []
+
+        def command(args, timeout):
+            self.calls.append(tuple(args))
+            if args[1:3] == ["status", "light.solder_led"]:
+                status = {
+                    "state": "on",
+                    "brightness": 170,
+                    "color_temp_kelvin": 2702,
+                }
+                return SimpleNamespace(returncode=0, stdout=json.dumps(status), stderr="")
+            if args[1:3] == ["status", "light.ext_led"]:
+                return SimpleNamespace(returncode=0, stdout=json.dumps(self.target), stderr="")
+            if args[1:3] == ["set", "light.ext_led"]:
+                self.target = {
+                    "state": "on",
+                    "brightness": int(args[3]),
+                    "color_temp_kelvin": int(args[4]),
+                }
+                return SimpleNamespace(returncode=0, stdout="{}", stderr="")
+            raise AssertionError(args)
+
+        self.manager = dashboard.CopLedManager(
+            self.store,
+            self.engine,
+            command=command,
+            clock=self.clock,
+            wall_clock=lambda: 1_700_000_000 + self.clock(),
+            retry_interval=5,
+            verify_interval=30,
+        )
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def test_waits_for_wifi_then_applies_and_confirms_reference_settings(self):
+        self.store.set("cop_alert", True)
+        waiting = self.manager.tick()
+        self.assertEqual(waiting["phase"], "waiting")
+        self.assertEqual(
+            waiting["desired"], {"brightness": 170, "color_temp_kelvin": 2702}
+        )
+        self.assertFalse(any(call[1] == "set" for call in self.calls))
+
+        self.target = {"state": "off", "brightness": 1, "color_temp_kelvin": 6500}
+        self.clock.advance(5)
+        confirmed = self.manager.tick()
+        self.assertEqual(confirmed["phase"], "confirmed")
+        self.assertIn("67%", confirmed["message"])
+        self.assertEqual(self.target["brightness"], 170)
+        self.assertEqual(self.target["color_temp_kelvin"], 2702)
+        self.assertTrue(any(call[1] == "set" for call in self.calls))
+
+    def test_pauses_while_engine_running_and_does_not_touch_light(self):
+        self.store.set("cop_alert", True)
+        self.engine.running = True
+        status = self.manager.tick()
+        self.assertEqual(status["phase"], "paused")
+        self.assertEqual(self.calls, [])
+
+    def test_reports_unavailable_after_wifi_grace_but_keeps_retrying(self):
+        self.store.set("cop_alert", True)
+        self.assertEqual(self.manager.tick()["phase"], "waiting")
+        self.clock.advance(dashboard.COP_LED_CONNECT_GRACE)
+        status = self.manager.tick()
+        self.assertEqual(status["phase"], "unavailable")
+        self.assertIn("still retrying", status["message"])
+        self.assertIsNotNone(status["last_error"])
+
+    def test_inactive_alert_never_queries_or_sets_lights(self):
+        status = self.manager.tick()
+        self.assertEqual(status["phase"], "inactive")
+        self.assertEqual(self.calls, [])
+
+    def test_uses_captured_settings_when_reference_cannot_be_read(self):
+        def command(args, timeout):
+            if args[1:3] == ["status", "light.solder_led"]:
+                return SimpleNamespace(returncode=1, stdout="", stderr="reference offline")
+            status = {"state": "unavailable", "brightness": None, "color_temp_kelvin": None}
+            return SimpleNamespace(returncode=0, stdout=json.dumps(status), stderr="")
+
+        manager = dashboard.CopLedManager(
+            self.store,
+            self.engine,
+            command=command,
+            clock=self.clock,
+            fallback_brightness=170,
+            fallback_kelvin=2702,
+        )
+        self.store.set("cop_alert", True)
+        status = manager.tick()
+        self.assertEqual(
+            status["desired"], {"brightness": 170, "color_temp_kelvin": 2702}
+        )
+        self.assertEqual(status["reference"], "captured solder_led fallback")
+
+
 class CopAlertManagerTests(unittest.TestCase):
     def setUp(self):
         self.tempdir = tempfile.TemporaryDirectory()
@@ -351,6 +459,7 @@ class DashboardRouteTests(unittest.TestCase):
         self.assertIn(b"COP ALERT", page.data)
         self.assertIn(b"Starlink", page.data)
         self.assertIn(b"MWAN3", page.data)
+        self.assertIn(b"ext_led", page.data)
         self.assertNotIn(b">Internet Connectivity<", page.data)
         self.assertNotIn(b">Reachable<", page.data)
         self.assertIn(b"Run speed test", page.data)

--- a/tests/test_van_dashboard.py
+++ b/tests/test_van_dashboard.py
@@ -1,0 +1,259 @@
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+from automation import van_dashboard as dashboard
+
+
+class FakeClock:
+    def __init__(self, value=100.0):
+        self.value = value
+
+    def __call__(self):
+        return self.value
+
+    def advance(self, seconds):
+        self.value += seconds
+
+
+class FakeEngine:
+    def __init__(self, running=False, rpm=0.0):
+        self.running = running
+        self.rpm = rpm
+
+    def snapshot(self):
+        return {
+            "running": self.running,
+            "rpm": self.rpm,
+            "evidence_age_seconds": 0.0 if self.running else None,
+            "frame_age_seconds": 0.0,
+            "source": "test",
+            "error": None,
+        }
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+class EngineMonitorTests(unittest.TestCase):
+    @staticmethod
+    def observe_running_pair(monitor):
+        monitor.observe(0x0F4, bytes.fromhex("17 80"))
+        monitor.observe(0x0FC, bytes.fromhex("0b c0"))
+
+    def test_rpm_decoder_matches_verified_capture_samples(self):
+        self.assertEqual(dashboard.rpm_from_engine_frame(0x0F4, bytes.fromhex("17 80")), 752.0)
+        self.assertEqual(dashboard.rpm_from_engine_frame(0x0FC, bytes.fromhex("0b c0")), 752.0)
+        self.assertEqual(dashboard.rpm_from_engine_frame(0x0F4, bytes.fromhex("00 00")), 0.0)
+        self.assertIsNone(dashboard.rpm_from_engine_frame(0x101, bytes.fromhex("17 80")))
+        self.assertIsNone(dashboard.rpm_from_engine_frame(0x0F4, b"\x17"))
+
+    def test_requires_repeated_fresh_running_frames(self):
+        clock = FakeClock()
+        monitor = dashboard.EngineMonitor(clock=clock)
+        for _ in range(dashboard.ENGINE_CONFIRM_FRAMES - 1):
+            self.observe_running_pair(monitor)
+        self.assertFalse(monitor.snapshot()["running"])
+
+        self.observe_running_pair(monitor)
+        self.assertTrue(monitor.snapshot()["running"])
+        self.assertEqual(monitor.snapshot()["rpm"], 752.0)
+
+        clock.advance(dashboard.ENGINE_EVIDENCE_MAX_AGE + 0.1)
+        self.assertFalse(monitor.snapshot()["running"])
+
+    def test_zero_rpm_immediately_revokes_running_evidence(self):
+        clock = FakeClock()
+        monitor = dashboard.EngineMonitor(clock=clock)
+        for _ in range(dashboard.ENGINE_CONFIRM_FRAMES):
+            self.observe_running_pair(monitor)
+        self.assertTrue(monitor.snapshot()["running"])
+        monitor.observe(0x0F4, bytes.fromhex("00 00"))
+        self.assertFalse(monitor.snapshot()["running"])
+
+    def test_implausibly_high_value_does_not_count_as_running(self):
+        clock = FakeClock()
+        monitor = dashboard.EngineMonitor(clock=clock)
+        for _ in range(dashboard.ENGINE_CONFIRM_FRAMES):
+            monitor.observe(0x0F4, bytes.fromhex("ff ff"))
+            monitor.observe(0x0FC, bytes.fromhex("ff ff"))
+        self.assertFalse(monitor.snapshot()["running"])
+
+    def test_one_rpm_source_alone_is_not_running_evidence(self):
+        clock = FakeClock()
+        monitor = dashboard.EngineMonitor(clock=clock)
+        for _ in range(dashboard.ENGINE_CONFIRM_FRAMES):
+            monitor.observe(0x0FC, bytes.fromhex("0b c0"))
+        self.assertFalse(monitor.snapshot()["running"])
+
+
+class CanLinkSafetyTests(unittest.TestCase):
+    @staticmethod
+    def command_with(output, returncode=0):
+        def command(_args, timeout):
+            return SimpleNamespace(stdout=output, stderr="", returncode=returncode)
+
+        return command
+
+    def test_accepts_existing_armed_c_can_without_mutation(self):
+        output = "4: can0: <NOARP,UP,LOWER_UP> state UP\n    can state ERROR-ACTIVE bitrate 500000"
+        ok, _ = dashboard.c_can_link_status(self.command_with(output))
+        self.assertTrue(ok)
+
+    def test_rejects_b_can_speed_and_listen_only(self):
+        bcan = "4: can0: <UP,LOWER_UP> state UP\n    can state ERROR-ACTIVE bitrate 125000"
+        listen = "4: can0: <UP,LOWER_UP> state UP\n    can <LISTEN-ONLY> bitrate 500000"
+        self.assertFalse(dashboard.c_can_link_status(self.command_with(bcan))[0])
+        self.assertFalse(dashboard.c_can_link_status(self.command_with(listen))[0])
+
+
+class FakeGroup:
+    def __init__(self):
+        self.coordinator = None
+        self.members = []
+
+
+class FakeSpeaker:
+    def __init__(self, name, volume, transport="STOPPED"):
+        self.player_name = name
+        self.volume = volume
+        self.transport = transport
+        self.is_visible = True
+        self.group = FakeGroup()
+        self.group.coordinator = self
+        self.group.members = [self]
+
+    def get_current_transport_info(self):
+        return {"current_transport_state": self.transport}
+
+
+class SonosControllerTests(unittest.TestCase):
+    def test_snapshot_selection_and_volume_match_audiobook_controls(self):
+        front = FakeSpeaker("Front", 28, "PLAYING")
+        rear = FakeSpeaker("Rear", 34)
+        front.group.members = [front, rear]
+        rear.group = front.group
+        solo = FakeSpeaker("Solo", 19)
+        zones = {front, rear, solo}
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            store = dashboard.StateStore(os.path.join(tempdir, "state.json"))
+            controller = dashboard.SonosController(store, discover_func=lambda timeout: zones)
+            snapshot = controller.snapshot()
+            self.assertEqual(snapshot["coordinator"], "Front")
+            grouped = {item["name"] for item in snapshot["speakers"] if item["grouped"]}
+            self.assertEqual(grouped, {"Front", "Rear"})
+            self.assertEqual(controller.set_volume("Rear", 42), 42)
+            self.assertEqual(rear.volume, 42)
+            self.assertEqual(controller.select("Solo"), "Solo")
+            self.assertEqual(store.get("sonos_device"), "Solo")
+
+
+class CopAlertManagerTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.clock = FakeClock()
+        self.engine = FakeEngine()
+        self.entity_state = "off"
+        self.calls = []
+        self.wakes = []
+        self.store = dashboard.StateStore(os.path.join(self.tempdir.name, "state.json"))
+
+        def command(args, timeout):
+            self.calls.append(tuple(args))
+            if args[0] == dashboard.TUYA_STATUS:
+                return SimpleNamespace(stdout=self.entity_state + "\n", stderr="", returncode=0)
+            if args[0] == dashboard.TUYA_TOGGLE:
+                self.entity_state = args[2]
+                return SimpleNamespace(stdout=args[2] + "\n", stderr="", returncode=0)
+            if args[0] == dashboard.NTFY_SEND:
+                return SimpleNamespace(stdout="", stderr="", returncode=0)
+            raise AssertionError(args)
+
+        def wake():
+            self.wakes.append(self.clock())
+            return True, "wake ok"
+
+        self.manager = dashboard.CopAlertManager(
+            self.store,
+            self.engine,
+            command=command,
+            wake=wake,
+            runtime_dir=os.path.join(self.tempdir.name, "run"),
+            clock=self.clock,
+            wall_clock=lambda: 1_700_000_000 + self.clock(),
+        )
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def test_parked_running_parked_transition(self):
+        status = self.manager.set_active(True)
+        self.assertTrue(status["active"])
+        self.assertEqual(self.entity_state, "on")
+        self.assertTrue(os.path.isfile(self.manager.active_marker))
+
+        self.manager.tick()
+        self.assertEqual(len(self.wakes), 1)
+        self.assertEqual(self.entity_state, "on")
+        self.assertTrue(any(call[0] == dashboard.NTFY_SEND for call in self.calls))
+        self.assertFalse(os.path.exists(self.manager.engine_marker))
+
+        self.engine.running = True
+        self.engine.rpm = 752.0
+        self.clock.advance(max(dashboard.FLOOD_CHECK_INTERVAL, dashboard.WAKE_INTERVAL) + 1)
+        self.manager.tick()
+        self.assertEqual(self.entity_state, "off")
+        self.assertEqual(len(self.wakes), 1, "running engine must suppress diagnostic wake")
+        self.assertTrue(os.path.isfile(self.manager.engine_marker))
+
+        self.engine.running = False
+        self.engine.rpm = 0.0
+        self.clock.advance(max(dashboard.FLOOD_CHECK_INTERVAL, dashboard.WAKE_INTERVAL) + 1)
+        self.manager.tick()
+        self.assertEqual(self.entity_state, "on")
+        self.assertEqual(len(self.wakes), 2)
+        self.assertFalse(os.path.exists(self.manager.engine_marker))
+
+        self.manager.set_active(False)
+        self.assertEqual(self.entity_state, "off")
+        self.assertFalse(os.path.exists(self.manager.active_marker))
+
+    def test_state_persists_across_manager_recreation(self):
+        self.manager.set_active(True)
+        reloaded = dashboard.StateStore(self.store.path)
+        self.assertTrue(reloaded.get("cop_alert"))
+
+
+class DashboardRouteTests(unittest.TestCase):
+    def test_index_and_manifest(self):
+        client = dashboard.app.test_client()
+        page = client.get("/")
+        self.assertEqual(page.status_code, 200)
+        self.assertIn(b"COP ALERT", page.data)
+        self.assertIn(b"bookUrl.port='8787'", page.data)
+        manifest = client.get("/manifest.webmanifest")
+        self.assertEqual(manifest.status_code, 200)
+        self.assertEqual(manifest.json["name"], "Van Dashboard")
+
+    def test_cop_alert_rejects_ambiguous_input_without_side_effects(self):
+        client = dashboard.app.test_client()
+        response = client.post("/api/cop-alert", data={"active": "maybe"})
+        self.assertEqual(response.status_code, 400)
+
+    def test_cross_origin_control_is_rejected(self):
+        client = dashboard.app.test_client()
+        response = client.post(
+            "/api/cop-alert",
+            data={"active": "true"},
+            headers={"Origin": "https://example.com", "X-Van-Dashboard": "1"},
+        )
+        self.assertEqual(response.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_van_dashboard.py
+++ b/tests/test_van_dashboard.py
@@ -117,13 +117,24 @@ class FakeGroup:
     def __init__(self):
         self.coordinator = None
         self.members = []
+        self.volume = 61
+        self.mute = False
 
 
 class FakeSpeaker:
     def __init__(self, name, volume, transport="STOPPED"):
         self.player_name = name
         self.volume = volume
+        self.mute = False
         self.transport = transport
+        self.track_info = {
+            "title": "Orange Juice",
+            "artist": "Stanley Brinks and The Wave Pictures",
+            "album": "",
+            "position": "0:01:23",
+            "duration": "0:03:45",
+        }
+        self.transport_calls = []
         self.is_visible = True
         self.group = FakeGroup()
         self.group.coordinator = self
@@ -131,6 +142,23 @@ class FakeSpeaker:
 
     def get_current_transport_info(self):
         return {"current_transport_state": self.transport}
+
+    def get_current_track_info(self):
+        return self.track_info
+
+    def pause(self):
+        self.transport_calls.append("pause")
+        self.transport = "PAUSED_PLAYBACK"
+
+    def play(self):
+        self.transport_calls.append("play")
+        self.transport = "PLAYING"
+
+    def previous(self):
+        self.transport_calls.append("previous")
+
+    def next(self):
+        self.transport_calls.append("next")
 
 
 class SonosControllerTests(unittest.TestCase):
@@ -144,15 +172,41 @@ class SonosControllerTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tempdir:
             store = dashboard.StateStore(os.path.join(tempdir, "state.json"))
+            store.set("sonos_device", "Front")
             controller = dashboard.SonosController(store, discover_func=lambda timeout: zones)
             snapshot = controller.snapshot()
             self.assertEqual(snapshot["coordinator"], "Front")
+            self.assertEqual(snapshot["group"], {"volume": 61, "muted": False})
+            self.assertEqual(snapshot["now_playing"]["title"], "Orange Juice")
+            self.assertEqual(
+                snapshot["now_playing"]["artist"],
+                "Stanley Brinks and The Wave Pictures",
+            )
             grouped = {item["name"] for item in snapshot["speakers"] if item["grouped"]}
             self.assertEqual(grouped, {"Front", "Rear"})
             self.assertEqual(controller.set_volume("Rear", 42), 42)
             self.assertEqual(rear.volume, 42)
+            self.assertTrue(controller.set_mute("Rear", True))
+            self.assertTrue(rear.mute)
+            self.assertEqual(controller.set_group_volume(73), 73)
+            self.assertEqual(front.group.volume, 73)
+            self.assertTrue(controller.set_group_mute(True))
+            self.assertTrue(front.group.mute)
+            self.assertEqual(controller.transport("play_pause"), "Sonos paused")
+            self.assertEqual(controller.transport("play_pause"), "Sonos playing")
+            self.assertEqual(controller.transport("previous"), "Previous Sonos track")
+            self.assertEqual(controller.transport("next"), "Next Sonos track")
+            self.assertEqual(front.transport_calls, ["pause", "play", "previous", "next"])
             self.assertEqual(controller.select("Solo"), "Solo")
             self.assertEqual(store.get("sonos_device"), "Solo")
+
+    def test_invalid_transport_action_fails_before_discovery(self):
+        controller = dashboard.SonosController(
+            dashboard.StateStore("/dev/null"),
+            discover_func=lambda timeout: self.fail("discovery should not run"),
+        )
+        with self.assertRaisesRegex(ValueError, "unknown Sonos transport action"):
+            controller.transport("shuffle")
 
 
 class ConnectivityMonitorTests(unittest.TestCase):
@@ -190,6 +244,8 @@ class ConnectivityMonitorTests(unittest.TestCase):
         self.assertEqual(status["router"]["mode"], "clientwan")
         self.assertEqual(status["ubnt"]["ssid"], "denlink")
         self.assertFalse(status["stale"])
+        monitor.request_refresh()
+        self.assertTrue(monitor.refresh_event.is_set())
 
 
 class TuyaSwitchManagerTests(unittest.TestCase):
@@ -433,6 +489,11 @@ class DashboardRouteTests(unittest.TestCase):
         self.assertNotIn(b">Internet Connectivity<", page.data)
         self.assertNotIn(b">Reachable<", page.data)
         self.assertIn(b"Run speed test", page.data)
+        self.assertIn(b'id="sonos-track"', page.data)
+        self.assertIn(b'data-transport="play_pause"', page.data)
+        self.assertIn(b"Group volume", page.data)
+        self.assertIn(b"data-group-mute", page.data)
+        self.assertIn(b"data-speaker-mute", page.data)
         self.assertIn(b"bookUrl.port='8787'", page.data)
         manifest = client.get("/manifest.webmanifest")
         self.assertEqual(manifest.status_code, 200)
@@ -442,10 +503,45 @@ class DashboardRouteTests(unittest.TestCase):
         client = dashboard.app.test_client()
         connectivity = client.get("/api/connectivity")
         self.assertEqual(connectivity.status_code, 200)
+        self.assertEqual(connectivity.headers["Cache-Control"], "no-store")
         self.assertIn("router", connectivity.json["connectivity"])
         speedtest = client.get("/api/speedtest")
         self.assertEqual(speedtest.status_code, 200)
         self.assertIn(speedtest.json["speedtest"]["status"], ("idle", "complete", "error"))
+
+    def test_sonos_transport_volume_and_mute_routes(self):
+        front = FakeSpeaker("Front", 28, "PLAYING")
+        with tempfile.TemporaryDirectory() as tempdir:
+            original = dashboard.sonos
+            dashboard.sonos = dashboard.SonosController(
+                dashboard.StateStore(os.path.join(tempdir, "state.json")),
+                discover_func=lambda timeout: {front},
+            )
+            try:
+                client = dashboard.app.test_client()
+                transport = client.post(
+                    "/api/speakers/transport", data={"action": "play_pause"}
+                )
+                group_volume = client.post(
+                    "/api/speakers/group-volume", data={"volume": "74"}
+                )
+                group_mute = client.post(
+                    "/api/speakers/group-mute", data={"muted": "true"}
+                )
+                speaker_mute = client.post(
+                    "/api/speakers/mute", data={"name": "Front", "muted": "true"}
+                )
+            finally:
+                dashboard.sonos = original
+
+        self.assertEqual(transport.status_code, 200)
+        self.assertEqual(front.transport_calls, ["pause"])
+        self.assertEqual(group_volume.json["volume"], 74)
+        self.assertEqual(front.group.volume, 74)
+        self.assertTrue(group_mute.json["muted"])
+        self.assertTrue(front.group.mute)
+        self.assertTrue(speaker_mute.json["muted"])
+        self.assertTrue(front.mute)
 
     def test_cop_alert_rejects_ambiguous_input_without_side_effects(self):
         client = dashboard.app.test_client()

--- a/tests/test_van_dashboard.py
+++ b/tests/test_van_dashboard.py
@@ -1,5 +1,7 @@
+import json
 import os
 import tempfile
+import threading
 import unittest
 from types import SimpleNamespace
 
@@ -153,6 +155,81 @@ class SonosControllerTests(unittest.TestCase):
             self.assertEqual(store.get("sonos_device"), "Solo")
 
 
+class ConnectivityMonitorTests(unittest.TestCase):
+    def test_refreshes_reusable_collector_into_cache(self):
+        payload = {
+            "checked_at": 1_700_000_100,
+            "internet": {"online": True},
+            "router": {
+                "reachable": True,
+                "mode": "clientwan",
+                "online": ["clientwan"],
+                "interfaces": [],
+                "error": None,
+            },
+            "ubnt": {
+                "reachable": True,
+                "connected": False,
+                "ssid": "denlink",
+                "error": None,
+            },
+        }
+
+        def command(args, timeout):
+            self.assertEqual(args, ["/test/connectivity"])
+            self.assertEqual(timeout, 25)
+            return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+
+        monitor = dashboard.ConnectivityMonitor(
+            collector="/test/connectivity",
+            command=command,
+            wall_clock=lambda: 1_700_000_110,
+        )
+        status = monitor.refresh()
+        self.assertTrue(status["internet"]["online"])
+        self.assertEqual(status["router"]["mode"], "clientwan")
+        self.assertEqual(status["ubnt"]["ssid"], "denlink")
+        self.assertFalse(status["stale"])
+
+
+class SpeedTestManagerTests(unittest.TestCase):
+    def test_parser_accepts_existing_speedtest_script_output(self):
+        output = "Download Speed: 42.75 Mbps\nUpload Speed:   8.5 Mbps\nLatency:        37.2 ms\n"
+        self.assertEqual(
+            dashboard.parse_speedtest_output(output),
+            {"download_mbps": 42.75, "upload_mbps": 8.5, "latency_ms": 37.2},
+        )
+
+    def test_speedtest_is_nonblocking_and_single_flight(self):
+        entered = threading.Event()
+        release = threading.Event()
+
+        def command(args, timeout):
+            self.assertEqual(args, ["/test/speedtest.sh"])
+            self.assertEqual(timeout, 180)
+            entered.set()
+            release.wait(2)
+            return SimpleNamespace(
+                returncode=0,
+                stdout="Download Speed: 50 Mbps\nUpload Speed: 10 Mbps\nLatency: 25 ms\n",
+                stderr="",
+            )
+
+        manager = dashboard.SpeedTestManager(
+            script="/test/speedtest.sh", command=command, timeout=180, wall_clock=lambda: 1234
+        )
+        self.assertTrue(manager.start())
+        self.assertTrue(entered.wait(1))
+        self.assertEqual(manager.snapshot()["status"], "running")
+        self.assertFalse(manager.start())
+        release.set()
+        manager.thread.join(2)
+        status = manager.snapshot()
+        self.assertEqual(status["status"], "complete")
+        self.assertEqual(status["download_mbps"], 50.0)
+        self.assertEqual(status["completed_at"], 1234)
+
+
 class CopAlertManagerTests(unittest.TestCase):
     def setUp(self):
         self.tempdir = tempfile.TemporaryDirectory()
@@ -235,10 +312,22 @@ class DashboardRouteTests(unittest.TestCase):
         page = client.get("/")
         self.assertEqual(page.status_code, 200)
         self.assertIn(b"COP ALERT", page.data)
+        self.assertIn(b"Internet Connectivity", page.data)
+        self.assertIn(b"mwan3 mode", page.data)
+        self.assertIn(b"Run speed test", page.data)
         self.assertIn(b"bookUrl.port='8787'", page.data)
         manifest = client.get("/manifest.webmanifest")
         self.assertEqual(manifest.status_code, 200)
         self.assertEqual(manifest.json["name"], "Van Dashboard")
+
+    def test_connectivity_and_speedtest_status_routes(self):
+        client = dashboard.app.test_client()
+        connectivity = client.get("/api/connectivity")
+        self.assertEqual(connectivity.status_code, 200)
+        self.assertIn("router", connectivity.json["connectivity"])
+        speedtest = client.get("/api/speedtest")
+        self.assertEqual(speedtest.status_code, 200)
+        self.assertIn(speedtest.json["speedtest"]["status"], ("idle", "complete", "error"))
 
     def test_cop_alert_rejects_ambiguous_input_without_side_effects(self):
         client = dashboard.app.test_client()


### PR DESCRIPTION
## Summary

- add a phone-friendly Van Dashboard web service on port 8788 with a host-preserving audiobook link
- expand the Sonos card with coordinator now-playing metadata and play/pause/previous/next controls
- add native Sonos group volume, group mute, individual volume, individual mute, and speaker-group selection controls
- add persistent COP ALERT behavior for `ext_flood`, verified C-CAN dashcam wake, dual-frame engine-running gating, and five-minute bacon ntfy messages
- add a separate COP exterior-LED worker that applies fixed brightness `170/255` and `2702 K` settings to `ext_led`, waits for Wi-Fi, confirms the result, and keeps retrying without blocking COP ALERT
- add a compact Connectivity card for mwan3 mode(s), UBNT Ethernet/radio state and signal quality, plus a cached reusable connectivity collector that performs no wireless scans
- make connectivity refresh reliably without a page reload: cache reads every 10 seconds, API requests bypass browser caches, returning to a suspended page refreshes immediately, and Starlink power changes wake the collector
- add consistent grey/no-data, red/down, and green/live status colors
- add a fail-closed Starlink Tuya power tile with cached polling and post-toggle verification
- add a single-flight asynchronous speed-test button around the existing `speedtest.sh`
- harden the Tuya helpers, add a credential-free `tuya_light.sh` status/set boundary, install the dashboard service, and document operations and B-CAN follow-up work
- document the separate vanpi CAN/UDS workspace and its transmission safeguards

## COP exterior LED behavior

- the desired look is hardcoded to brightness `170/255` (67%) and `2702 K`, captured from `solder_led` on 2026-07-18
- COP ALERT never reads or depends on `solder_led` at activation time
- the worker runs independently and polls `light.ext_led` every five seconds while it joins Wi-Fi
- after a 90-second grace period it reports unavailable while continuing retries, covering RF blockage by the van shell
- successful settings are read back for confirmation and re-verified every 30 seconds
- verified engine-running periods pause LED work because COP ALERT intentionally turns `ext_flood` off then

## Safety behavior

- the dashboard never changes the shared CAN interface bitrate, link state, or listen-only mode
- CAN wake is refused unless `can0` is already armed at the verified C-CAN bitrate
- engine-running requires repeated plausible readings from both `0x0F4` and `0x0FC`; missing, stale, single-source, or implausible evidence fails closed
- exterior-light Wi-Fi/configuration failure never disarms COP ALERT or interrupts CAN wake, `ext_flood`, or ntfy behavior
- connectivity collection uses bounded read-only queries and existing mwan3 tracking; browser polling only reads the in-process cache
- unavailable Starlink state is grey/disabled rather than guessing a toggle direction
- speed tests are manual-only, off-request, single-flight, and bounded
- no credentials are added to the dashboard, and browser control POSTs reject cross-origin requests

## Validation

- all 30 unit tests passed with `/usr/bin/python3` on `vanpi`, including Sonos metadata/transport/group-volume/mute APIs, connectivity parsing/caching/refresh behavior, fixed exterior-light settings, delayed availability, engine-running pause behavior, Tuya verification, nonblocking speed tests, COP transitions, C-CAN guards, persistence, and CSRF handling
- the Sonos implementation was checked against vanpi's installed SoCo API and live state using read-only inspection; no playback, volume, grouping, or mute changes were issued during validation
- `tuya_light.sh status` was exercised read-only against Home Assistant; no light service call was issued
- `python3 -m py_compile`, extracted dashboard `node --check`, `git diff --cached --check`, and staged-scope checks passed

Live deployment of the latest revision, bandwidth testing, light mutation, and CAN transmission were intentionally not performed during validation.
