### PR TITLE
Separate ignition from requested disk state

### DIFF
--- a/pi/TODO.md
+++ b/pi/TODO.md
@@ -32,9 +32,12 @@
   having the configuration-writing command request the service; use a
   systemd `.path` unit only as a fallback for changes made elsewhere.
 
-- [ ] Separate the user's requested configuration from the ignition override.
+- [x] Separate the user's requested configuration from the ignition override.
   Derive effective policy from both inputs instead of replacing `mconf` with
   `nodisk` and later restoring `mconf_last`.
+  - `mconf` remains the requested state. The observed `ignition_is_on` flag is
+    an unconditional disk-safety override, and both ignition transitions run
+    reconciliation without modifying the requested state.
 
 - [ ] Keep periodic reconciliation after event triggers are deployed. Replace
   the minutely cron invocation only after event coverage is verified, then use

--- a/pi/hooks/ignition_off.sh
+++ b/pi/hooks/ignition_off.sh
@@ -1,19 +1,16 @@
 #! /bin/bash
 isw="$HOME/scripts/internet_switches.sh"
-mconf="$HOME/mconf"
 log="$HOME/log/ignition_monitor.log"
 
-echo ""
-echo "$(date)"
-echo "ignition OFF hook invoked"
+echo "" >> "$log"
+echo "$(date)" >> "$log"
+echo "ignition OFF hook invoked" >> "$log"
 
-if [ -d "${mconf}_last" ]; then
-  echo "moving mconf_last dir to mconf, running ISW script" >> $log
-  rm -rf $mconf
-  mv "${mconf}_last" $mconf 
-  $isw
+if "$isw"; then
+  echo "Ignition OFF at $(date)" >> "$log"
+  echo "VAN OFF DONE"
 else
-  echo "no mconf_last dir, NO ACTION" >> $log
+  rc=$?
+  echo "Ignition OFF policy failed with status $rc" >> "$log"
+  exit "$rc"
 fi
-echo "Ignition OFF at $(date)" >> $log
-echo "VAN OFF DONE"

--- a/pi/hooks/ignition_on.sh
+++ b/pi/hooks/ignition_on.sh
@@ -4,15 +4,7 @@ tuya_toggle="$HOME/scripts/tuya_toggle.sh"
 tuya_device_ids="$HOME/scripts/tuya_device_ids.sh"
 cop_alert_ext_flood_guard="$HOME/scripts/cop_alert_ext_flood_guard.sh"
 inactive="$HOME/hooks/inactive/ignition"
-mconf="$HOME/mconf"
 log="$HOME/log/ignition_monitor.log"
-
-nodisk() { rm $mconf/*; touch $mconf/nodisk; $isw; }
-
-stop_disks() {
-  cp -R $mconf "${mconf}_last"
-  nodisk
-}
 
 
 turn_lights_off() {
@@ -28,15 +20,20 @@ turn_lights_off() {
   done
 }
 
-echo "" >> $log
-echo "$(date)" >> $log
-echo "Ignition ON script invoked" >> $log
+echo "" >> "$log"
+echo "$(date)" >> "$log"
+echo "Ignition ON script invoked" >> "$log"
 
-if cat $inactive; then
-  echo "(ignition monitor INACTIVE)" >> $log
+if [[ -f "$inactive" ]]; then
+  echo "(ignition monitor INACTIVE)" >> "$log"
 else
-  echo "ignition monitor ACTIVE" >> $log
+  echo "ignition monitor ACTIVE" >> "$log"
   turn_lights_off &
-  stop_disks
-  echo "IGNITION ON DONE" >> $log
+  if "$isw"; then
+    echo "IGNITION ON DONE" >> "$log"
+  else
+    rc=$?
+    echo "IGNITION ON policy failed with status $rc" >> "$log"
+    exit "$rc"
+  fi
 fi

--- a/pi/scripts/internet_switches.sh
+++ b/pi/scripts/internet_switches.sh
@@ -10,6 +10,8 @@ ISW_LOG_FILE=${ISW_LOG_FILE:-/var/log/cron/internet_switches.log}
 ISW_NTFY_SEND=${ISW_NTFY_SEND:-/home/pi/scripts/ntfy_send.sh}
 ISW_MWAN_HOST=${ISW_MWAN_HOST:-root@OpenWrt}
 ISW_MWAN_TIMEOUT_SECONDS=${ISW_MWAN_TIMEOUT_SECONDS:-12}
+ISW_MCONF_DIR=${ISW_MCONF_DIR:-/home/pi/mconf}
+ISW_IGNITION_FLAG=${ISW_IGNITION_FLAG:-/home/pi/hooks/ignition_is_on}
 ISW_MWAN_STATE=""
 
 isw_prepare_canary_dir() {
@@ -158,7 +160,11 @@ isw_notify_recovery() {
   /usr/bin/rm -f -- "$ISW_ALERT_FILE"
 }
 
-conf() { cat /home/pi/mconf/$1* &> /dev/null; }
+conf() { cat "$ISW_MCONF_DIR"/"$1"* &> /dev/null; }
+
+ignition_is_on() {
+  test -f "$ISW_IGNITION_FLAG"
+}
 
 ubnt_internet_ops() { # nanostation connected; van is likely stationary/parked
   echo 'ubnt_internet_ops'
@@ -247,7 +253,7 @@ start_torrent_client() {
 mount_drives() {
   if [[ $(van_is_running) ]]; then
     echo "MOUNT interrupt: van is running, unmounting drives"
-    echo "will not mount drives without idisk conf flag!"
+    echo "will not mount drives while ignition is on"
     kill_torrent_client
     stop_service smbd 
     sleep 1
@@ -262,9 +268,7 @@ mount_drives() {
 }
 
 van_is_running() {
-  if test -f /home/pi/hooks/ignition_is_on; then
-    [ -z "$(conf idisk)" ] && echo "yes"
-  fi
+  ignition_is_on && echo "yes"
 }
 
 unmount_drives() {
@@ -323,7 +327,13 @@ iface_online() {
 set_isw_options() {
   echo ""
   echo "$(date)"
-  if conf nodisk &> /dev/null; then kill_all # drives disabled ~/mconf/nodisk
+  # mconf is requested state owned by the user/dashboard. Ignition is observed
+  # state and is an unconditional safety override; never rewrite mconf to
+  # represent it. When ignition turns off, the latest requested state applies.
+  if ignition_is_on; then
+    echo "ignition is on; overriding requested disk policy"
+    kill_all
+  elif conf nodisk &> /dev/null; then kill_all # drives disabled ~/mconf/nodisk
   else
     # WAN transitions happen behind the Pi's stable LAN connection. OpenWrt
     # pushes a reconciliation request, then the Pi verifies current mwan3

--- a/pi/tests/test_ignition_policy.sh
+++ b/pi/tests/test_ignition_policy.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -u
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected=$1 actual=$2 description=$3
+  [[ "$actual" == "$expected" ]] ||
+    fail "$description (expected '$expected', got '$actual')"
+}
+
+export ISW_MCONF_DIR="$test_root/mconf"
+export ISW_IGNITION_FLAG="$test_root/ignition_is_on"
+mkdir -p "$ISW_MCONF_DIR"
+
+# shellcheck source=../scripts/internet_switches.sh
+source "$repo_root/pi/scripts/internet_switches.sh"
+
+ACTION=""
+kill_all() { ACTION=kill_all; }
+mobile_internet_ops() { ACTION=mobile_internet_ops; }
+lifi_internet_ops() { ACTION=lifi_internet_ops; }
+ubnt_internet_ops() { ACTION=ubnt_internet_ops; }
+no_internet_ops() { ACTION=no_internet_ops; }
+refresh_mwan_state() {
+  ISW_MWAN_STATE=$'Interface status:\n interface clientwan is online'
+}
+
+touch "$ISW_MCONF_DIR/idisk" "$ISW_MCONF_DIR/mdisk" "$ISW_MCONF_DIR/mtorrent"
+requested_before=$(ls -1 "$ISW_MCONF_DIR" | sort)
+touch "$ISW_IGNITION_FLAG"
+set_isw_options >/dev/null || fail "ignition-on policy returned failure"
+assert_eq kill_all "$ACTION" "ignition must override requested disk state"
+assert_eq "$requested_before" "$(ls -1 "$ISW_MCONF_DIR" | sort)" \
+  "policy must not modify requested state"
+
+rm "$ISW_IGNITION_FLAG" "$ISW_MCONF_DIR/idisk" \
+  "$ISW_MCONF_DIR/mdisk" "$ISW_MCONF_DIR/mtorrent"
+touch "$ISW_MCONF_DIR/nodisk"
+ACTION=""
+set_isw_options >/dev/null || fail "nodisk policy returned failure"
+assert_eq kill_all "$ACTION" "nodisk must disable disks while parked"
+
+rm "$ISW_MCONF_DIR/nodisk"
+touch "$ISW_MCONF_DIR/mdisk"
+ACTION=""
+set_isw_options >/dev/null || fail "parked requested policy returned failure"
+assert_eq mobile_internet_ops "$ACTION" \
+  "parked policy must apply the latest requested state"
+
+hook_home="$test_root/hook-home"
+mkdir -p "$hook_home/scripts" "$hook_home/hooks/inactive" \
+  "$hook_home/log" "$hook_home/mconf"
+touch "$hook_home/mconf/mdisk" "$hook_home/mconf/mtorrent"
+
+for helper in tuya_toggle.sh tuya_device_ids.sh cop_alert_ext_flood_guard.sh; do
+  printf '#!/bin/bash\nexit 0\n' > "$hook_home/scripts/$helper"
+  chmod +x "$hook_home/scripts/$helper"
+done
+printf '#!/bin/bash\nprintf "run\\n" >> "$HOME/policy_calls"\nsleep 1\n' \
+  > "$hook_home/scripts/internet_switches.sh"
+chmod +x "$hook_home/scripts/internet_switches.sh"
+
+hook_requested_before=$(ls -1 "$hook_home/mconf" | sort)
+HOME="$hook_home" bash "$repo_root/pi/hooks/ignition_on.sh" >/dev/null ||
+  fail "ignition-on hook returned failure"
+HOME="$hook_home" bash "$repo_root/pi/hooks/ignition_off.sh" >/dev/null ||
+  fail "ignition-off hook returned failure"
+assert_eq "$hook_requested_before" "$(ls -1 "$hook_home/mconf" | sort)" \
+  "ignition hooks must not modify requested state"
+[[ ! -e "$hook_home/mconf_last" ]] || fail "ignition hooks created mconf_last"
+assert_eq 2 "$(wc -l < "$hook_home/policy_calls" | tr -d ' ')" \
+  "both ignition transitions must reconcile policy"
+
+echo "PASS: ignition policy keeps requested state separate"


### PR DESCRIPTION
## What changed

- Keep `/home/pi/mconf` as persistent requested state instead of replacing it during ignition transitions.
- Treat the observed `ignition_is_on` flag as an unconditional disk-safety override in `internet_switches.sh`.
- Reconcile on both ignition transitions without creating, restoring, or deleting `mconf_last`.
- Add an isolated regression test for ignition, parked, and hook behavior.

## Why

The ignition hooks previously encoded runtime state by deleting `mconf`, writing `nodisk`, and later restoring a snapshot. That could discard dashboard changes made while the vehicle was running and made requested state difficult to reason about. Effective policy is now derived from independent requested and observed inputs.

## Validation

- `bash -n` on the changed shell scripts and regression test
- `pi/tests/test_ignition_policy.sh` on macOS
- the same isolated test on vanpi
- atomically deployed the runtime files to vanpi and completed a successful `vanpi-policy.service` reconciliation
- confirmed `mdisk`/`mtorrent` were unchanged, `mconf_last` absent, ignition monitor active, lifecycle lock free, and all existing mounts intact
