### PR TITLE
Replace mconf with policyctl

### DIFF
--- a/pi/.bashrc
+++ b/pi/.bashrc
@@ -144,8 +144,6 @@ s() { # run ~/scripts/<name>.sh or .py, drilling into subfolders if not at top l
 sx() { sudo "$(history | perl -pe 's/^\s+[0-9]+\**\s+//g' | tail -1)"; }
 svc() { sudo systemctl $2 $1.service; } # svc home-assistant start
 alias iswl="tf /var/log/cron/internet_switches.log"
-isw="$HOME/scripts/internet_switches.sh"
-mconf="$HOME/mconf"
 
 sync_comps() {
   sync_dirpath '/Users/jacobr/Library/Application Support/BetterTouchTool/'
@@ -171,21 +169,16 @@ sync_dirpath() {
   rsync -ur "$locpath" "$i9:'$syncpath'"
 }
 
-# mconf - mobile disk and torrenting configuration
-alias mconf="ls $mconf"
-alias mreset="rm $mconf/*; nohup $isw &"
-alias mdisk="rm $mconf/nodisk*; rm $mconf/notorrent*; touch $mconf/mdisk; nohup $isw &"
-alias mdiskx="rm $mconf/mdisk*; nohup $isw &"
-alias idisk="rm $mconf/nodisk*; touch $mconf/idisk; nohup $isw &"
-alias idiskx="rm $mconf/idisk*; nohup $isw &"
-alias notor="rm $mconf/mtorrent*; touch $mconf/notorrent; nohup $isw &"
-alias notorx="rm $mconf/notorrent*; nohup $isw &"
-alias mtor="rm $mconf/notorrent* $mconf/nodisk*; touch $mconf/mtorrent; nohup $isw &"
-alias mtorx="rm $mconf/mtorrent*; nohup $isw &"
-alias nodisk="rm $mconf/mdisk*; touch $mconf/nodisk; nohup $isw &"
-alias nodiskx="rm $mconf/nodisk*; nohup $isw &"
-alias startor="touch $mconf/startor; nohup $isw &" # starlink torrent
-alias startorx="rm $mconf/startor; nohup $isw &"
+# Requested storage/torrent policy. policyctl writes atomically and requests
+# reconciliation; the dashboard uses the same command.
+alias policyctl='$HOME/scripts/policyctl'
+alias mconf='$HOME/scripts/policyctl status'
+alias nodisk='$HOME/scripts/policyctl disks off'
+alias nodiskx='$HOME/scripts/policyctl disks on'
+alias notor='$HOME/scripts/policyctl torrents off'
+alias notorx='$HOME/scripts/policyctl torrents on'
+alias startor='$HOME/scripts/policyctl starlink-torrents on'
+alias startorx='$HOME/scripts/policyctl starlink-torrents off'
 
 # status hooks
 alias ignitmonoff="touch $HOME/hooks/inactive/ignition"

--- a/pi/POLICY.md
+++ b/pi/POLICY.md
@@ -1,0 +1,66 @@
+# Vanpi storage and torrent policy
+
+`/home/pi/.config/vanpi/policy.json` is the single source of requested state:
+
+```json
+{
+  "allow_starlink_torrents": false,
+  "disks_enabled": true,
+  "torrents_enabled": true,
+  "version": 1
+}
+```
+
+Only `/home/pi/scripts/policyctl` should modify this file. It validates the
+complete document, serializes writers with `flock`, atomically replaces the
+file, and requests `vanpi-policy.service` after a change. The dashboard and
+interactive shell aliases use this same interface.
+
+## Effective policy
+
+Ignition is observed safety state and always overrides requested state:
+
+| Condition | Disks | qBittorrent |
+| --- | --- | --- |
+| Ignition on | unmounted and spun down | stopped |
+| Disks disabled | unmounted and spun down | stopped |
+| Torrents disabled | mounted | stopped |
+| Starlink on or unknown, permission disabled | mounted | stopped |
+| Starlink on, permission enabled, torrents enabled | mounted | running |
+| Starlink off, torrents enabled | mounted | running |
+
+In particular, Starlink torrenting requires both `torrents_enabled=true` and
+`allow_starlink_torrents=true`. An unavailable or unrecognized Starlink power
+state fails closed unless Starlink torrent permission was explicitly granted.
+
+Disk availability no longer depends on mwan3 state, upstream Wi-Fi attachment,
+or internet availability. While parked, disks are mounted unless explicitly
+disabled. qBittorrent may remain running without an internet uplink and resume
+naturally when connectivity returns.
+
+## Commands and aliases
+
+```bash
+policyctl status
+policyctl --json status
+policyctl disks on|off
+policyctl torrents on|off
+policyctl starlink-torrents on|off
+policyctl reconcile
+```
+
+The Bash aliases retain the previous short names:
+
+- `nodisk` / `nodiskx`: disable / enable parked storage
+- `notor` / `notorx`: disable / enable all torrenting
+- `startor` / `startorx`: allow / block torrenting while Starlink is on
+- `mconf`: display the requested policy
+
+`policyctl migrate` creates the policy from legacy `mconf`, `mconf_last`, and
+`starconf` markers without overwriting an existing policy. After migration and
+deployment, those legacy directories are no longer read.
+
+If the policy file is missing or invalid while parked, reconciliation returns
+an error without inferring a mount or unmount request. Ignition-on handling
+still stops qBittorrent and spins down disks even when requested policy cannot
+be read.

--- a/pi/TODO.md
+++ b/pi/TODO.md
@@ -19,22 +19,26 @@
 
 - [x] Trigger policy reconciliation from OpenWrt when mwan3 uplink state
   changes. Pi-side NetworkManager cannot observe those transitions because the
-  Pi-to-router LAN connection remains up. The router notification should mean
-  only "reconcile now"; the Pi should then query mwan3 once for authoritative
-  current state.
+  Pi-to-router LAN connection remains up. The router notification means only
+  "reconcile now."
   - Use a dedicated, forced-command credential that can only request the
     policy service; do not give the router general SSH access to the Pi or
     other devices.
   - Make the router hook non-blocking, bounded by a short timeout, and tolerant
     of duplicate events.
+  - Disk and torrent policy no longer varies by mwan3 state. Remove this
+    trigger after confirming it has no remaining policy consumer.
 
-- [ ] Trigger reconciliation when the requested configuration changes. Prefer
+- [x] Trigger reconciliation when the requested configuration changes. Prefer
   having the configuration-writing command request the service; use a
   systemd `.path` unit only as a fallback for changes made elsewhere.
+  - `policyctl` is the sole writer and requests `vanpi-policy.service` after an
+    atomic update.
 
-- [ ] Separate the user's requested configuration from the ignition override.
-  Derive effective policy from both inputs instead of replacing `mconf` with
-  `nodisk` and later restoring `mconf_last`.
+- [x] Separate the user's requested configuration from the ignition override.
+  Requested state lives in `~/.config/vanpi/policy.json`; ignition is an
+  unconditional observed-state override. The hooks never rewrite requested
+  state or create `mconf_last`.
 
 - [ ] Keep periodic reconciliation after event triggers are deployed. Replace
   the minutely cron invocation only after event coverage is verified, then use

--- a/pi/hooks/ignition_off.sh
+++ b/pi/hooks/ignition_off.sh
@@ -1,19 +1,16 @@
 #! /bin/bash
 isw="$HOME/scripts/internet_switches.sh"
-mconf="$HOME/mconf"
 log="$HOME/log/ignition_monitor.log"
 
-echo ""
-echo "$(date)"
-echo "ignition OFF hook invoked"
+echo "" >> "$log"
+echo "$(date)" >> "$log"
+echo "ignition OFF hook invoked" >> "$log"
 
-if [ -d "${mconf}_last" ]; then
-  echo "moving mconf_last dir to mconf, running ISW script" >> $log
-  rm -rf $mconf
-  mv "${mconf}_last" $mconf 
-  $isw
+if "$isw"; then
+  echo "Ignition OFF at $(date)" >> "$log"
+  echo "VAN OFF DONE"
 else
-  echo "no mconf_last dir, NO ACTION" >> $log
+  rc=$?
+  echo "Ignition OFF policy failed with status $rc" >> "$log"
+  exit "$rc"
 fi
-echo "Ignition OFF at $(date)" >> $log
-echo "VAN OFF DONE"

--- a/pi/hooks/ignition_on.sh
+++ b/pi/hooks/ignition_on.sh
@@ -4,15 +4,7 @@ tuya_toggle="$HOME/scripts/tuya_toggle.sh"
 tuya_device_ids="$HOME/scripts/tuya_device_ids.sh"
 cop_alert_ext_flood_guard="$HOME/scripts/cop_alert_ext_flood_guard.sh"
 inactive="$HOME/hooks/inactive/ignition"
-mconf="$HOME/mconf"
 log="$HOME/log/ignition_monitor.log"
-
-nodisk() { rm $mconf/*; touch $mconf/nodisk; $isw; }
-
-stop_disks() {
-  cp -R $mconf "${mconf}_last"
-  nodisk
-}
 
 
 turn_lights_off() {
@@ -28,15 +20,20 @@ turn_lights_off() {
   done
 }
 
-echo "" >> $log
-echo "$(date)" >> $log
-echo "Ignition ON script invoked" >> $log
+echo "" >> "$log"
+echo "$(date)" >> "$log"
+echo "Ignition ON script invoked" >> "$log"
 
-if cat $inactive; then
-  echo "(ignition monitor INACTIVE)" >> $log
+if [[ -f "$inactive" ]]; then
+  echo "(ignition monitor INACTIVE)" >> "$log"
 else
-  echo "ignition monitor ACTIVE" >> $log
+  echo "ignition monitor ACTIVE" >> "$log"
   turn_lights_off &
-  stop_disks
-  echo "IGNITION ON DONE" >> $log
+  if "$isw"; then
+    echo "IGNITION ON DONE" >> "$log"
+  else
+    rc=$?
+    echo "IGNITION ON policy failed with status $rc" >> "$log"
+    exit "$rc"
+  fi
 fi

--- a/pi/scripts/internet_switches.sh
+++ b/pi/scripts/internet_switches.sh
@@ -8,9 +8,12 @@ ISW_ALERT_FILE="$ISW_CANARY_DIR/alerted"
 ISW_ALERT_LOCK="$ISW_CANARY_DIR/alert.lock"
 ISW_LOG_FILE=${ISW_LOG_FILE:-/var/log/cron/internet_switches.log}
 ISW_NTFY_SEND=${ISW_NTFY_SEND:-/home/pi/scripts/ntfy_send.sh}
-ISW_MWAN_HOST=${ISW_MWAN_HOST:-root@OpenWrt}
-ISW_MWAN_TIMEOUT_SECONDS=${ISW_MWAN_TIMEOUT_SECONDS:-12}
-ISW_MWAN_STATE=""
+ISW_POLICYCTL=${ISW_POLICYCTL:-/home/pi/scripts/policyctl}
+ISW_IGNITION_FLAG=${ISW_IGNITION_FLAG:-/home/pi/hooks/ignition_is_on}
+ISW_TUYA_STATUS=${ISW_TUYA_STATUS:-/home/pi/scripts/tuya_status.sh}
+POLICY_DISKS_ENABLED=""
+POLICY_TORRENTS_ENABLED=""
+POLICY_ALLOW_STARLINK_TORRENTS=""
 
 isw_prepare_canary_dir() {
   if [[ -L "$ISW_CANARY_DIR" || ( -e "$ISW_CANARY_DIR" && ! -d "$ISW_CANARY_DIR" ) ]]; then
@@ -158,71 +161,56 @@ isw_notify_recovery() {
   /usr/bin/rm -f -- "$ISW_ALERT_FILE"
 }
 
-conf() { cat /home/pi/mconf/$1* &> /dev/null; }
+ignition_is_on() {
+  test -f "$ISW_IGNITION_FLAG"
+}
 
-ubnt_internet_ops() { # nanostation connected; van is likely stationary/parked
-  echo 'ubnt_internet_ops'
-  mount_drives
-  sleep 1
-  if conf notorrent || has_io_error '/mnt/movingparts' || starlink_notor
-  then kill_torrent_client 
-  else start_torrent_client
+load_requested_policy() {
+  local output status
+  output=$("$ISW_POLICYCTL" read 2>&1)
+  status=$?
+  if (( status != 0 )); then
+    echo "ERROR: unable to read requested policy (status $status): $output" >&2
+    return 1
+  fi
+  read -r POLICY_DISKS_ENABLED POLICY_TORRENTS_ENABLED \
+    POLICY_ALLOW_STARLINK_TORRENTS <<< "$output"
+  if [[ ! "$POLICY_DISKS_ENABLED" =~ ^[01]$ ||
+        ! "$POLICY_TORRENTS_ENABLED" =~ ^[01]$ ||
+        ! "$POLICY_ALLOW_STARLINK_TORRENTS" =~ ^[01]$ ]]; then
+    echo "ERROR: policyctl returned an invalid compact policy: $output" >&2
+    return 1
   fi
 }
 
-starlink_notor() {
-  local status=$(/home/pi/scripts/tuya_status.sh starlink)
-  if [ "$status" = "on" ]; then
-    [ ! -e /home/pi/mconf/startor ]
-  else
-    return 1 # false
+starlink_blocks_torrents() {
+  local state status
+
+  # Explicit permission makes the Starlink state irrelevant. The global
+  # torrent switch is checked separately and still takes precedence.
+  [[ "$POLICY_ALLOW_STARLINK_TORRENTS" == 1 ]] && return 1
+
+  state=$("$ISW_TUYA_STATUS" starlink 2>&1)
+  status=$?
+  if (( status != 0 )); then
+    echo "WARNING: Starlink state is unavailable; blocking torrents: $state" >&2
+    return 0
   fi
+  case "$state" in
+    off) return 1 ;;
+    on)
+      echo "Starlink is on and Starlink torrents are not allowed"
+      return 0
+      ;;
+    *)
+      echo "WARNING: unrecognized Starlink state '$state'; blocking torrents" >&2
+      return 0
+      ;;
+  esac
 }
 
 has_io_error() { ls -lah "$1" 2>&1 | grep -q 'Input/output error'; }
 # if has_io_error '/mnt/movingparts'; then echo 'i/o error'; fi
-
-update_iface_score() {
-  file=$1
-  iface_score=`cat $file` 
-  if [ "$iface_score" -lt "$lowest_score" ]; then
-    echo "IS LES"
-    lowest_score=$iface_score
-    iface=`basename "$(dirname $file)"`
-    echo "set iface. l: $lowest_score, f: $file, iface: $iface"
-  fi
-}
-
-mobile_internet_ops() {
-  echo 'mobile_internet_ops'
-  if conf mtorrent; then ubnt_internet_ops; else no_internet_ops; fi
-}
-
-lifi_internet_ops() {
-  echo 'lifi_internet_ops'
-  if conf mtorrent_lifi; then
-    echo "lifi-tor allowed"
-    ubnt_internet_ops
-  else
-    no_internet_ops
-  fi
-}
-
-no_internet_ops() {
-  echo 'no_internet_ops'
-  if conf mtorrent; then 
-    mount_drives
-    start_torrent_client
-  elif conf mdisk; then 
-    mount_drives
-    kill_torrent_client
-  else 
-    kill_torrent_client
-    unmount_drives
-  fi 
-    
-  
-}
 
 kill_torrent_client() {
   if [[ "$(ps ax)" == *"qbittorrent"* ]]; then echo 'killtorrent' && pkill -TERM qbittorrent; fi
@@ -247,11 +235,12 @@ start_torrent_client() {
 mount_drives() {
   if [[ $(van_is_running) ]]; then
     echo "MOUNT interrupt: van is running, unmounting drives"
-    echo "will not mount drives without idisk conf flag!"
+    echo "will not mount drives while ignition is on"
     kill_torrent_client
     stop_service smbd 
     sleep 1
     unmount_drives
+    return 1
   else
     /home/pi/scripts/umount_disks.sh --clear-spindown-state || return 1
     . /home/pi/scripts/mount_disks.sh
@@ -262,9 +251,7 @@ mount_drives() {
 }
 
 van_is_running() {
-  if test -f /home/pi/hooks/ignition_is_on; then
-    [ -z "$(conf idisk)" ] && echo "yes"
-  fi
+  ignition_is_on && echo "yes"
 }
 
 unmount_drives() {
@@ -286,54 +273,38 @@ kill_all() {
   unmount_drives
 }
 
-refresh_mwan_state() {
-  local state
-  local status
-
-  state="$(/usr/bin/timeout --kill-after=2s "${ISW_MWAN_TIMEOUT_SECONDS}s" \
-    /usr/bin/ssh \
-      -n \
-      -o BatchMode=yes \
-      -o ConnectTimeout=5 \
-      -o ServerAliveInterval=3 \
-      -o ServerAliveCountMax=1 \
-      "$ISW_MWAN_HOST" \
-      '/usr/sbin/mwan3 interfaces' 2>&1)"
-  status=$?
-  if (( status != 0 )); then
-    echo "ERROR: unable to query mwan3 state from $ISW_MWAN_HOST (status $status)" >&2
-    printf '%s\n' "$state" >&2
-    return 1
-  fi
-  if [[ -z "$state" ]] || ! /usr/bin/grep -Fq 'Interface status:' <<< "$state"; then
-    echo "ERROR: mwan3 returned an empty or unrecognized interface report" >&2
-    return 1
-  fi
-
-  ISW_MWAN_STATE="$state"
-}
-
-iface_online() {
-  local interface="$1"
-  /usr/bin/grep -Fq " interface $interface is online" <<< "$ISW_MWAN_STATE"
-}
-
-# if date | grep '0:0'; then date; fi
-# ubnt_internet_ops
 set_isw_options() {
   echo ""
   echo "$(date)"
-  if conf nodisk &> /dev/null; then kill_all # drives disabled ~/mconf/nodisk
+  # Ignition is observed safety state and always wins, even if requested
+  # policy is missing or corrupt.
+  if ignition_is_on; then
+    echo "ignition is on; disabling and spinning down disks"
+    kill_all
+    return
+  fi
+
+  load_requested_policy || return 1
+  if [[ "$POLICY_DISKS_ENABLED" == 0 ]]; then
+    echo "requested policy disables disks"
+    kill_all
+    return
+  fi
+
+  # Parked storage is normally available. Uplink attachment no longer decides
+  # whether it is safe to spin disks; ignition_monitor owns that decision.
+  mount_drives || return 1
+
+  if [[ "$POLICY_TORRENTS_ENABLED" == 0 ]]; then
+    echo "requested policy disables torrents"
+    kill_torrent_client
+  elif has_io_error '/mnt/movingparts'; then
+    echo "movingparts has an I/O error; disabling torrents" >&2
+    kill_torrent_client
+  elif starlink_blocks_torrents; then
+    kill_torrent_client
   else
-    # WAN transitions happen behind the Pi's stable LAN connection. OpenWrt
-    # pushes a reconciliation request, then the Pi verifies current mwan3
-    # state once here. A failed query is not evidence that every WAN is down.
-    refresh_mwan_state || return 1
-    if iface_online clientwan; then mobile_internet_ops
-    elif iface_online lifiwan; then lifi_internet_ops
-    elif iface_online wan; then ubnt_internet_ops
-    else no_internet_ops
-    fi
+    start_torrent_client
   fi
 }
 #

--- a/pi/scripts/policyctl
+++ b/pi/scripts/policyctl
@@ -1,0 +1,285 @@
+#!/usr/bin/python3
+"""Read and update vanpi's requested storage and torrent policy."""
+
+import argparse
+import fcntl
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+import tempfile
+
+
+POLICY_PATH = Path(
+    os.environ.get("VANPI_POLICY_PATH", "/home/pi/.config/vanpi/policy.json")
+)
+LOCK_PATH = Path(
+    os.environ.get("VANPI_POLICY_LOCK_PATH", "/home/pi/.config/vanpi/policy.lock")
+)
+LEGACY_MCONF = Path(os.environ.get("VANPI_POLICY_MCONF", "/home/pi/mconf"))
+LEGACY_MCONF_LAST = Path(
+    os.environ.get("VANPI_POLICY_MCONF_LAST", "/home/pi/mconf_last")
+)
+LEGACY_STARCONF = Path(
+    os.environ.get("VANPI_POLICY_STARCONF", "/home/pi/starconf")
+)
+POLICY_VERSION = 1
+POLICY_FIELDS = (
+    "disks_enabled",
+    "torrents_enabled",
+    "allow_starlink_torrents",
+)
+TARGET_FIELDS = {
+    "disks": "disks_enabled",
+    "torrents": "torrents_enabled",
+    "starlink-torrents": "allow_starlink_torrents",
+}
+
+
+class PolicyError(RuntimeError):
+    pass
+
+
+def ensure_state_directory():
+    POLICY_PATH.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    LOCK_PATH.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+
+def policy_lock(exclusive):
+    ensure_state_directory()
+    if LOCK_PATH.is_symlink():
+        raise PolicyError(f"refusing symlink lock path: {LOCK_PATH}")
+    descriptor = os.open(LOCK_PATH, os.O_RDWR | os.O_CREAT, 0o600)
+    os.fchmod(descriptor, 0o600)
+    handle = os.fdopen(descriptor, "r+")
+    fcntl.flock(handle, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+    return handle
+
+
+def validate_policy(value):
+    if not isinstance(value, dict):
+        raise PolicyError("policy must be a JSON object")
+    expected = {"version", *POLICY_FIELDS}
+    unknown = set(value) - expected
+    missing = expected - set(value)
+    if unknown:
+        raise PolicyError(f"unknown policy fields: {', '.join(sorted(unknown))}")
+    if missing:
+        raise PolicyError(f"missing policy fields: {', '.join(sorted(missing))}")
+    if value["version"] != POLICY_VERSION:
+        raise PolicyError(f"unsupported policy version: {value['version']!r}")
+    for field in POLICY_FIELDS:
+        if type(value[field]) is not bool:
+            raise PolicyError(f"{field} must be true or false")
+    return value
+
+
+def read_policy_unlocked():
+    try:
+        with POLICY_PATH.open(encoding="utf-8") as handle:
+            return validate_policy(json.load(handle))
+    except FileNotFoundError as exc:
+        raise PolicyError(f"policy is not initialized; run: policyctl migrate") from exc
+    except json.JSONDecodeError as exc:
+        raise PolicyError(f"invalid JSON in {POLICY_PATH}: {exc}") from exc
+    except OSError as exc:
+        raise PolicyError(f"cannot read {POLICY_PATH}: {exc}") from exc
+
+
+def read_policy():
+    with policy_lock(exclusive=False):
+        return read_policy_unlocked()
+
+
+def atomic_write_policy(value):
+    validate_policy(value)
+    ensure_state_directory()
+    temporary_name = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=".policy.", dir=str(POLICY_PATH.parent)
+        )
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, POLICY_PATH)
+        temporary_name = None
+        os.chmod(POLICY_PATH, 0o600)
+        try:
+            directory_fd = os.open(POLICY_PATH.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except OSError:
+            # The atomic replacement is still valid on filesystems that do not
+            # support fsync on a directory.
+            pass
+    finally:
+        if temporary_name:
+            try:
+                os.unlink(temporary_name)
+            except FileNotFoundError:
+                pass
+
+
+def has_marker(directory, prefixes):
+    try:
+        entries = tuple(directory.iterdir())
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise PolicyError(f"cannot inspect legacy policy directory {directory}: {exc}")
+    return any(
+        entry.is_file() and any(entry.name.startswith(prefix) for prefix in prefixes)
+        for entry in entries
+    )
+
+
+def migrated_policy():
+    # While the old ignition hook is active, mconf is temporary nodisk state
+    # and mconf_last contains the actual requested state.
+    requested = LEGACY_MCONF_LAST if LEGACY_MCONF_LAST.is_dir() else LEGACY_MCONF
+    disks_enabled = not has_marker(requested, ("nodisk",))
+    torrents_enabled = not has_marker(requested, ("notorrent", "notor"))
+    allow_starlink = has_marker(requested, ("startor",))
+    if not requested.is_dir() and LEGACY_STARCONF.is_dir():
+        # The older starconf convention allowed Starlink torrents when its
+        # `notor` marker was absent. An existing mconf/mconf_last uses the
+        # newer startor marker convention and takes precedence over starconf.
+        allow_starlink = not has_marker(LEGACY_STARCONF, ("notor",))
+    return {
+        "version": POLICY_VERSION,
+        "disks_enabled": disks_enabled,
+        "torrents_enabled": torrents_enabled,
+        "allow_starlink_torrents": allow_starlink,
+    }
+
+
+def migrate_policy():
+    with policy_lock(exclusive=True):
+        if POLICY_PATH.exists():
+            return read_policy_unlocked(), False
+        value = migrated_policy()
+        atomic_write_policy(value)
+        return value, True
+
+
+def update_policy(field, enabled):
+    with policy_lock(exclusive=True):
+        value = dict(read_policy_unlocked())
+        value[field] = enabled
+        atomic_write_policy(value)
+        return value
+
+
+def request_reconciliation():
+    configured = os.environ.get("VANPI_POLICY_REQUEST_COMMAND")
+    command = (
+        shlex.split(configured)
+        if configured
+        else [
+            "/usr/bin/sudo",
+            "-n",
+            "/usr/bin/systemctl",
+            "start",
+            "--no-block",
+            "vanpi-policy.service",
+        ]
+    )
+    if not command:
+        raise PolicyError("policy request command is empty")
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, timeout=8)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise PolicyError(f"could not request policy reconciliation: {exc}") from exc
+    if result.returncode:
+        detail = (result.stderr or result.stdout or "command failed").strip()
+        raise PolicyError(f"could not request policy reconciliation: {detail}")
+
+
+def parse_on_off(value):
+    if value == "on":
+        return True
+    if value == "off":
+        return False
+    raise PolicyError("state must be 'on' or 'off'")
+
+
+def print_policy(value, as_json=False):
+    if as_json:
+        json.dump(value, sys.stdout, sort_keys=True)
+        sys.stdout.write("\n")
+        return
+    rows = (
+        ("Disks", "enabled" if value["disks_enabled"] else "disabled"),
+        ("Torrents", "enabled" if value["torrents_enabled"] else "disabled"),
+        (
+            "Starlink torrents",
+            "allowed" if value["allow_starlink_torrents"] else "blocked",
+        ),
+    )
+    for label, state in rows:
+        print(f"{label}: {state}")
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Manage requested vanpi storage and torrent policy"
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    parser.add_argument(
+        "--no-reconcile",
+        action="store_true",
+        help="update requested state without starting vanpi-policy.service",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("status", help="show requested policy")
+    subparsers.add_parser("read", help="emit the compact policy used by the reconciler")
+    subparsers.add_parser("migrate", help="initialize policy from legacy markers")
+    subparsers.add_parser("reconcile", help="request policy reconciliation now")
+    for command in TARGET_FIELDS:
+        target = subparsers.add_parser(command, help=f"turn {command} on or off")
+        target.add_argument("state", choices=("on", "off"))
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    changed = False
+    if args.command in ("status", "reconcile"):
+        value = read_policy()
+    elif args.command == "read":
+        value = read_policy()
+        if args.json:
+            print_policy(value, as_json=True)
+        else:
+            print(
+                int(value["disks_enabled"]),
+                int(value["torrents_enabled"]),
+                int(value["allow_starlink_torrents"]),
+            )
+        return 0
+    elif args.command == "migrate":
+        value, changed = migrate_policy()
+    else:
+        value = update_policy(TARGET_FIELDS[args.command], parse_on_off(args.state))
+        changed = True
+
+    if (changed or args.command == "reconcile") and not args.no_reconcile:
+        request_reconciliation()
+    print_policy(value, as_json=args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except PolicyError as exc:
+        print(f"policyctl: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/pi/tests/test_policy_reconciliation.sh
+++ b/pi/tests/test_policy_reconciliation.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+set -u
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected=$1 actual=$2 description=$3
+  [[ "$actual" == "$expected" ]] ||
+    fail "$description (expected '$expected', got '$actual')"
+}
+
+cat > "$test_root/policyctl" <<'HELPER'
+#!/bin/bash
+printf '%s\n' "$TEST_COMPACT_POLICY"
+HELPER
+cat > "$test_root/tuya-status" <<'HELPER'
+#!/bin/bash
+printf 'called\n' >> "$TEST_STARLINK_CALLS"
+printf '%s\n' "$TEST_STARLINK_STATE"
+exit "$TEST_STARLINK_STATUS"
+HELPER
+chmod +x "$test_root/policyctl" "$test_root/tuya-status"
+
+export ISW_POLICYCTL="$test_root/policyctl"
+export ISW_IGNITION_FLAG="$test_root/ignition_is_on"
+export ISW_TUYA_STATUS="$test_root/tuya-status"
+export TEST_STARLINK_CALLS="$test_root/starlink-calls"
+
+# shellcheck source=../scripts/internet_switches.sh
+source "$repo_root/pi/scripts/internet_switches.sh"
+
+ACTION=""
+IO_ERROR=1
+mount_drives() { ACTION="${ACTION:+$ACTION }mount"; }
+kill_torrent_client() { ACTION="${ACTION:+$ACTION }kill-torrent"; }
+start_torrent_client() { ACTION="${ACTION:+$ACTION }start-torrent"; }
+kill_all() { ACTION="${ACTION:+$ACTION }kill-all"; }
+has_io_error() { return "$IO_ERROR"; }
+
+run_case() {
+  local description=$1 policy=$2 starlink_state=$3 starlink_status=$4 expected=$5
+  export TEST_COMPACT_POLICY=$policy
+  export TEST_STARLINK_STATE=$starlink_state
+  export TEST_STARLINK_STATUS=$starlink_status
+  ACTION=""
+  IO_ERROR=1
+  rm -f "$TEST_STARLINK_CALLS"
+  set_isw_options >/dev/null 2>&1 || fail "$description returned failure"
+  assert_eq "$expected" "$ACTION" "$description"
+}
+
+touch "$ISW_IGNITION_FLAG"
+export TEST_COMPACT_POLICY="invalid"
+ACTION=""
+set_isw_options >/dev/null 2>&1 || fail "ignition override returned failure"
+assert_eq "kill-all" "$ACTION" "ignition must override unreadable requested policy"
+rm "$ISW_IGNITION_FLAG"
+
+run_case "disabled disks" "0 1 1" off 0 "kill-all"
+run_case "globally disabled torrents" "1 0 1" off 0 "mount kill-torrent"
+run_case "explicit Starlink permission" "1 1 1" unknown 1 "mount start-torrent"
+[[ ! -e "$TEST_STARLINK_CALLS" ]] ||
+  fail "explicit Starlink permission should not query Starlink power"
+run_case "Starlink blocked" "1 1 0" on 0 "mount kill-torrent"
+run_case "non-Starlink torrenting" "1 1 0" off 0 "mount start-torrent"
+run_case "unknown Starlink fails closed" "1 1 0" unknown 1 "mount kill-torrent"
+
+export TEST_COMPACT_POLICY="1 1 0"
+export TEST_STARLINK_STATE=off
+export TEST_STARLINK_STATUS=0
+ACTION=""
+IO_ERROR=0
+rm -f "$TEST_STARLINK_CALLS"
+set_isw_options >/dev/null 2>&1 || fail "I/O-error policy returned failure"
+assert_eq "mount kill-torrent" "$ACTION" "I/O error must stop torrents"
+[[ ! -e "$TEST_STARLINK_CALLS" ]] || fail "I/O error should skip Starlink query"
+
+export TEST_COMPACT_POLICY="1 maybe 0"
+ACTION=""
+if set_isw_options >/dev/null 2>&1; then
+  fail "invalid compact policy was accepted"
+fi
+assert_eq "" "$ACTION" "invalid requested policy must not change runtime state"
+
+hook_home="$test_root/hook-home"
+mkdir -p "$hook_home/scripts" "$hook_home/hooks/inactive" \
+  "$hook_home/log" "$hook_home/.config/vanpi"
+printf '{"sentinel":true}\n' > "$hook_home/.config/vanpi/policy.json"
+for helper in tuya_toggle.sh tuya_device_ids.sh cop_alert_ext_flood_guard.sh; do
+  printf '#!/bin/bash\nexit 0\n' > "$hook_home/scripts/$helper"
+  chmod +x "$hook_home/scripts/$helper"
+done
+printf '#!/bin/bash\nprintf "run\\n" >> "$HOME/policy_calls"\nsleep 1\n' \
+  > "$hook_home/scripts/internet_switches.sh"
+chmod +x "$hook_home/scripts/internet_switches.sh"
+
+policy_before=$(cat "$hook_home/.config/vanpi/policy.json")
+HOME="$hook_home" bash "$repo_root/pi/hooks/ignition_on.sh" >/dev/null ||
+  fail "ignition-on hook returned failure"
+HOME="$hook_home" bash "$repo_root/pi/hooks/ignition_off.sh" >/dev/null ||
+  fail "ignition-off hook returned failure"
+assert_eq "$policy_before" "$(cat "$hook_home/.config/vanpi/policy.json")" \
+  "ignition hooks must not modify requested state"
+[[ ! -e "$hook_home/mconf_last" ]] || fail "ignition hooks created mconf_last"
+assert_eq 2 "$(wc -l < "$hook_home/policy_calls" | tr -d ' ')" \
+  "both ignition transitions must reconcile policy"
+
+echo "PASS: storage and torrent policy reconciliation"

--- a/tests/test_policyctl.py
+++ b/tests/test_policyctl.py
@@ -1,0 +1,141 @@
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import unittest
+
+
+POLICYCTL = Path(__file__).resolve().parents[1] / "pi" / "scripts" / "policyctl"
+
+
+class PolicyctlTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.policy = self.root / "config" / "policy.json"
+        self.mconf = self.root / "mconf"
+        self.mconf_last = self.root / "mconf_last"
+        self.starconf = self.root / "starconf"
+        self.environment = {
+            **os.environ,
+            "VANPI_POLICY_PATH": str(self.policy),
+            "VANPI_POLICY_LOCK_PATH": str(self.root / "config" / "policy.lock"),
+            "VANPI_POLICY_MCONF": str(self.mconf),
+            "VANPI_POLICY_MCONF_LAST": str(self.mconf_last),
+            "VANPI_POLICY_STARCONF": str(self.starconf),
+        }
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def run_policyctl(self, *arguments, check=True, environment=None):
+        result = subprocess.run(
+            [str(POLICYCTL), *arguments],
+            capture_output=True,
+            text=True,
+            env=environment or self.environment,
+            check=False,
+        )
+        if check and result.returncode:
+            self.fail(f"policyctl failed: {result.stderr or result.stdout}")
+        return result
+
+    def read_policy(self):
+        return json.loads(self.policy.read_text(encoding="utf-8"))
+
+    def test_migrate_uses_new_always_available_defaults(self):
+        result = self.run_policyctl("--no-reconcile", "--json", "migrate")
+        self.assertEqual(
+            json.loads(result.stdout),
+            {
+                "version": 1,
+                "disks_enabled": True,
+                "torrents_enabled": True,
+                "allow_starlink_torrents": False,
+            },
+        )
+        self.assertEqual(stat.S_IMODE(self.policy.stat().st_mode), 0o600)
+        self.assertEqual(
+            self.run_policyctl("read").stdout.strip(),
+            "1 1 0",
+        )
+
+    def test_migrate_prefers_requested_state_saved_in_mconf_last(self):
+        self.mconf.mkdir()
+        (self.mconf / "nodisk").touch()
+        self.mconf_last.mkdir()
+        (self.mconf_last / "notorrent").touch()
+        (self.mconf_last / "startor").touch()
+
+        self.run_policyctl("--no-reconcile", "migrate")
+
+        self.assertEqual(
+            self.read_policy(),
+            {
+                "version": 1,
+                "disks_enabled": True,
+                "torrents_enabled": False,
+                "allow_starlink_torrents": True,
+            },
+        )
+
+    def test_migrate_understands_legacy_starconf_permission(self):
+        self.starconf.mkdir()
+        self.run_policyctl("--no-reconcile", "migrate")
+        self.assertTrue(self.read_policy()["allow_starlink_torrents"])
+
+        self.policy.unlink()
+        (self.starconf / "notor").touch()
+        self.run_policyctl("--no-reconcile", "migrate")
+        self.assertFalse(self.read_policy()["allow_starlink_torrents"])
+
+    def test_mconf_startor_convention_wins_over_stale_starconf(self):
+        self.mconf.mkdir()
+        self.starconf.mkdir()
+
+        self.run_policyctl("--no-reconcile", "migrate")
+
+        self.assertFalse(self.read_policy()["allow_starlink_torrents"])
+
+    def test_update_changes_one_field_and_requests_reconciliation(self):
+        self.run_policyctl("--no-reconcile", "migrate")
+        request_marker = self.root / "requested"
+        request_command = self.root / "request-policy"
+        request_command.write_text(
+            f"#!/bin/bash\ntouch {request_marker}\n", encoding="utf-8"
+        )
+        request_command.chmod(0o700)
+        environment = {
+            **self.environment,
+            "VANPI_POLICY_REQUEST_COMMAND": str(request_command),
+        }
+
+        result = self.run_policyctl(
+            "--json", "torrents", "off", environment=environment
+        )
+
+        self.assertTrue(request_marker.exists())
+        value = json.loads(result.stdout)
+        self.assertTrue(value["disks_enabled"])
+        self.assertFalse(value["torrents_enabled"])
+        self.assertFalse(value["allow_starlink_torrents"])
+
+        request_marker.unlink()
+        self.run_policyctl("reconcile", environment=environment)
+        self.assertTrue(request_marker.exists())
+
+    def test_invalid_policy_fails_without_guessing(self):
+        self.policy.parent.mkdir(parents=True)
+        self.policy.write_text('{"disks_enabled": true}\n', encoding="utf-8")
+
+        result = self.run_policyctl("read", check=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("missing policy fields", result.stderr)
+        self.assertEqual(self.policy.read_text(encoding="utf-8"), '{"disks_enabled": true}\n')
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- replace `mconf`, `mconf_last`, and `starconf` marker state with one validated, atomically written policy file
- add `policyctl` for status, migration, disk/torrent/Starlink permission changes, and reconciliation requests
- simplify `internet_switches.sh` so storage availability depends on ignition and explicit disk policy, never WAN or known-Wi-Fi attachment
- require both global torrent permission and Starlink torrent permission when Starlink is on
- fail closed for torrenting when Starlink power state is unavailable and permission was not granted
- preserve the `nodisk`, `notor`, and `startor` alias families through `policyctl`
- remove ignition-hook mutation and restoration of requested configuration
- document and test the policy matrix and legacy migration

## Why

The old marker directory combined requested state, observed ignition state, and historical assumptions about network attachment. It could discard requested changes during an ignition cycle and made disk behavior vary with the active WAN even though ignition monitoring now supplies the actual safety boundary.

The new policy has three explicit booleans: disks enabled, torrents enabled, and Starlink torrents allowed. The reconciler derives effective state from those values plus ignition, disk health, and Starlink power.

## Validation

- six `policyctl` unit/integration tests pass on macOS and vanpi
- shell policy matrix and ignition-hook regression test passes on macOS and vanpi
- changed shell scripts pass `bash -n`; diff passes whitespace checks
- migrated live state to disks enabled, torrents enabled, Starlink torrents blocked
- verified the policy file is mode `0600`, legacy directories are absent, ignition monitor is active, service reconciliation succeeds, and the lifecycle lock is free
- live reconciliation correctly kept qBittorrent stopped while Starlink was on

The live check also found a pre-existing stale `/mnt/movingparts` mount: it references vanished `/dev/sde1` while the labeled device is now `/dev/sdg1`. The policy correctly detects the I/O error and keeps qBittorrent stopped; repairing that mount is intentionally outside this PR.
