### PR TITLE
Harden qBittorrent process control

### DIFF
--- a/pi/scripts/internet_switches.sh
+++ b/pi/scripts/internet_switches.sh
@@ -11,6 +11,11 @@ ISW_NTFY_SEND=${ISW_NTFY_SEND:-/home/pi/scripts/ntfy_send.sh}
 ISW_POLICYCTL=${ISW_POLICYCTL:-/home/pi/scripts/policyctl}
 ISW_IGNITION_FLAG=${ISW_IGNITION_FLAG:-/home/pi/hooks/ignition_is_on}
 ISW_TUYA_STATUS=${ISW_TUYA_STATUS:-/home/pi/scripts/tuya_status.sh}
+ISW_PGREP=${ISW_PGREP:-/usr/bin/pgrep}
+ISW_PKILL=${ISW_PKILL:-/usr/bin/pkill}
+ISW_SLEEP=${ISW_SLEEP:-/usr/bin/sleep}
+ISW_QBIT_PROCESS=${ISW_QBIT_PROCESS:-qbittorrent-nox}
+ISW_QBIT_BINARY=${ISW_QBIT_BINARY:-/usr/bin/qbittorrent-nox}
 POLICY_DISKS_ENABLED=""
 POLICY_TORRENTS_ENABLED=""
 POLICY_ALLOW_STARLINK_TORRENTS=""
@@ -213,18 +218,52 @@ has_io_error() { ls -lah "$1" 2>&1 | grep -q 'Input/output error'; }
 # if has_io_error '/mnt/movingparts'; then echo 'i/o error'; fi
 
 kill_torrent_client() {
-  if [[ "$(ps ax)" == *"qbittorrent"* ]]; then echo 'killtorrent' && pkill -TERM qbittorrent; fi
-  sleep 2
-  if [[ "$(ps ax)" == *"qbittorrent"* ]]; then echo 'SECOND ATTEMPT killtorrent' && pkill -f qbittorrent; fi
-  sleep 2
+  local rc
+  local attempt
+
+  "$ISW_PGREP" -x "$ISW_QBIT_PROCESS" >/dev/null 2>&1
+  rc=$?
+  (( rc == 1 )) && return 0
+  if (( rc != 0 )); then
+    echo "ERROR: cannot inspect $ISW_QBIT_PROCESS processes (pgrep status $rc)" >&2
+    return 1
+  fi
+
+  echo "asking $ISW_QBIT_PROCESS to stop"
+  "$ISW_PKILL" -TERM -x "$ISW_QBIT_PROCESS"
+  rc=$?
+  (( rc <= 1 )) || return 1
+
+  # qBittorrent can need about 18 seconds to save state and exit. Keep the
+  # shutdown graceful, but do not let policy reconciliation wait forever.
+  for attempt in {1..30}; do
+    "$ISW_PGREP" -x "$ISW_QBIT_PROCESS" >/dev/null 2>&1
+    rc=$?
+    (( rc == 1 )) && return 0
+    if (( rc != 0 )); then
+      echo "ERROR: cannot verify $ISW_QBIT_PROCESS shutdown (pgrep status $rc)" >&2
+      return 1
+    fi
+    "$ISW_SLEEP" 1
+  done
+
+  echo "ERROR: $ISW_QBIT_PROCESS did not stop within 30 seconds" >&2
+  return 1
 }
 
 start_torrent_client() {
+  local rc
+
   if [[ "$(grep movingparts /proc/mounts)" ]]; then 
-    if ! pgrep qbittor >/dev/null; then
+    "$ISW_PGREP" -x "$ISW_QBIT_PROCESS" >/dev/null 2>&1
+    rc=$?
+    if (( rc == 1 )); then
       # Background only qbittorrent—not the surrounding conditional—and do
       # not let the long-lived client inherit fd 9 and hold our flock.
-      nohup qbittorrent-nox 9>&- &
+      /usr/bin/nohup "$ISW_QBIT_BINARY" 9>&- &
+    elif (( rc != 0 )); then
+      echo "ERROR: cannot inspect $ISW_QBIT_PROCESS processes (pgrep status $rc)" >&2
+      return 1
     fi
   else
     echo "preventing torrent-without-mpdisk"
@@ -268,7 +307,7 @@ start_service() {
 
 kill_all() {
   echo 'killing all'
-  kill_torrent_client
+  kill_torrent_client || return 1
   sleep 4
   unmount_drives
 }

--- a/pi/scripts/umount_disks.sh
+++ b/pi/scripts/umount_disks.sh
@@ -281,20 +281,20 @@ ud_parent_is_unmounted() {
 
 ud_kill_torrent_client() {
   local rc attempt
-  /usr/bin/pgrep -f '[q]bittorrent-nox' >/dev/null 2>&1
+  /usr/bin/pgrep -x qbittorrent-nox >/dev/null 2>&1
   rc=$?
   (( rc == 1 )) && return 0
   (( rc == 0 )) || return 1
 
   echo "asking qbittorrent-nox to stop"
-  /usr/bin/sudo /usr/bin/pkill -TERM -f '[q]bittorrent-nox'
+  /usr/bin/sudo /usr/bin/pkill -TERM -x qbittorrent-nox
   rc=$?
   (( rc <= 1 )) || return 1
 
   # This Pi's qBittorrent can need about 18 seconds to save state and exit.
   # Keep the stop graceful, but bound ignition shutdown at 30 seconds.
   for attempt in {1..30}; do
-    /usr/bin/pgrep -f '[q]bittorrent-nox' >/dev/null 2>&1
+    /usr/bin/pgrep -x qbittorrent-nox >/dev/null 2>&1
     rc=$?
     (( rc == 1 )) && return 0
     (( rc == 0 )) || return 1

--- a/pi/tests/test_policy_reconciliation.sh
+++ b/pi/tests/test_policy_reconciliation.sh
@@ -27,15 +27,71 @@ printf 'called\n' >> "$TEST_STARLINK_CALLS"
 printf '%s\n' "$TEST_STARLINK_STATE"
 exit "$TEST_STARLINK_STATUS"
 HELPER
-chmod +x "$test_root/policyctl" "$test_root/tuya-status"
+cat > "$test_root/pgrep" <<'HELPER'
+#!/bin/bash
+[[ "$#" == 2 && "$1" == -x && "$2" == qbittorrent-nox ]] || exit 99
+printf '%s\n' "$*" >> "$TEST_PGREP_CALLS"
+count=0
+[[ ! -f "$TEST_PGREP_COUNT" ]] || read -r count < "$TEST_PGREP_COUNT"
+count=$((count + 1))
+printf '%s\n' "$count" > "$TEST_PGREP_COUNT"
+(( count <= TEST_PGREP_RUNNING_CALLS ))
+HELPER
+cat > "$test_root/pkill" <<'HELPER'
+#!/bin/bash
+[[ "$#" == 3 && "$1" == -TERM && "$2" == -x && "$3" == qbittorrent-nox ]] || exit 99
+printf '%s\n' "$*" >> "$TEST_PKILL_CALLS"
+exit "${TEST_PKILL_STATUS:-0}"
+HELPER
+cat > "$test_root/sleep" <<'HELPER'
+#!/bin/bash
+[[ "$#" == 1 && "$1" == 1 ]] || exit 99
+printf '%s\n' "$1" >> "$TEST_SLEEP_CALLS"
+HELPER
+chmod +x "$test_root/policyctl" "$test_root/tuya-status" \
+  "$test_root/pgrep" "$test_root/pkill" "$test_root/sleep"
 
 export ISW_POLICYCTL="$test_root/policyctl"
 export ISW_IGNITION_FLAG="$test_root/ignition_is_on"
 export ISW_TUYA_STATUS="$test_root/tuya-status"
+export ISW_PGREP="$test_root/pgrep"
+export ISW_PKILL="$test_root/pkill"
+export ISW_SLEEP="$test_root/sleep"
 export TEST_STARLINK_CALLS="$test_root/starlink-calls"
+export TEST_PGREP_CALLS="$test_root/pgrep-calls"
+export TEST_PGREP_COUNT="$test_root/pgrep-count"
+export TEST_PKILL_CALLS="$test_root/pkill-calls"
+export TEST_SLEEP_CALLS="$test_root/sleep-calls"
 
 # shellcheck source=../scripts/internet_switches.sh
 source "$repo_root/pi/scripts/internet_switches.sh"
+
+reset_process_test() {
+  export TEST_PGREP_RUNNING_CALLS=$1
+  export TEST_PKILL_STATUS=${2:-0}
+  rm -f "$TEST_PGREP_CALLS" "$TEST_PGREP_COUNT" \
+    "$TEST_PKILL_CALLS" "$TEST_SLEEP_CALLS"
+}
+
+reset_process_test 0
+kill_torrent_client >/dev/null 2>&1 || fail "absent torrent client was a stop failure"
+[[ ! -e "$TEST_PKILL_CALLS" ]] || fail "absent torrent client was signaled"
+assert_eq "-x qbittorrent-nox" "$(cat "$TEST_PGREP_CALLS")" \
+  "torrent discovery must use exact process identity"
+
+reset_process_test 1
+kill_torrent_client >/dev/null 2>&1 || fail "graceful torrent stop returned failure"
+assert_eq "-TERM -x qbittorrent-nox" "$(cat "$TEST_PKILL_CALLS")" \
+  "torrent stop must signal only the exact process identity"
+assert_eq 2 "$(cat "$TEST_PGREP_COUNT")" \
+  "graceful torrent stop must verify process exit"
+
+reset_process_test 31
+if kill_torrent_client >/dev/null 2>&1; then
+  fail "stuck torrent client was reported stopped"
+fi
+assert_eq 30 "$(wc -l < "$TEST_SLEEP_CALLS" | tr -d ' ')" \
+  "stuck torrent stop must be bounded at 30 seconds"
 
 ACTION=""
 IO_ERROR=1


### PR DESCRIPTION
## What changed

- Replace full-command-line and partial-name process matching with exact `qbittorrent-nox` identity checks.
- Use exact identity for both policy reconciliation and guarded disk unmounts.
- Give qBittorrent up to 30 seconds to exit gracefully after `TERM`, then return a real failure instead of escalating to broad `pkill -f`.
- Refuse to report disk-disable success when the torrent client did not stop.
- Use the same exact identity before starting qBittorrent, preventing duplicate starts on discovery errors.
- Add regression coverage for absent, graceful-exit, and stuck-client cases, including exact `pgrep`/`pkill` arguments.

## Why

The previous fallback searched every process's full command line for the word `qbittorrent`. A diagnostic SSH shell containing that word was therefore mistaken for the client and killed. Partial-name startup detection also treated discovery errors as absence.

## Impact

Only a process whose kernel name is exactly `qbittorrent-nox` can be detected or signaled. Shutdown remains graceful and bounded, while policy failures are now visible to callers.

## Validation

- `bash -n pi/scripts/internet_switches.sh pi/scripts/umount_disks.sh pi/tests/test_policy_reconciliation.sh`
- `pi/tests/test_policy_reconciliation.sh`
- `pi/tests/test_mount_disks.sh`
- The regression suite passed on vanpi.
- A live unrelated shell containing `qbittorrent-nox` in its full command line survived.
- A live exact-name dummy process was gracefully terminated, followed by a successful normal policy reconciliation.
